### PR TITLE
Rails 2.3.5 compatibility

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -36,7 +36,7 @@ module Recaptcha
           html << %{</noscript>\n}
         end
       end
-      return html.html_safe
+      return (html.respond_to?(:html_safe) && html.html_safe) || html
     end # recaptcha_tags
   end # ClientHelper
 end # Recaptcha


### PR DESCRIPTION
Hi, 

I've changed recaptcha_tags to only mark the result html_safe if there is support for that. 
The gem didn't work on Rails 2.3.5 and apparently the rails_xss gem doesn't work with it either.

Thanks,
Zoltan 
