### PR TITLE
Ability to disable recaptcha verification by setting ENV["SKIP_RECAPTCHA_VERIFY"]

### DIFF
--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -3,6 +3,8 @@ module Recaptcha
     # Your private API can be specified in the +options+ hash or preferably
     # using the Configuration.
     def verify_recaptcha(options = {})
+      return true unless ENV["SKIP_RECAPTCHA_VERIFY"].to_i == 0
+
       if !options.is_a? Hash
         options = {:model => options}
       end

--- a/test/verify_recaptcha_test.rb
+++ b/test/verify_recaptcha_test.rb
@@ -70,6 +70,22 @@ class RecaptchaVerifyTest < Test::Unit::TestCase
     assert_equal "recaptcha-not-reachable", @controller.flash[:recaptcha_error]
   end
 
+  def test_verify_gets_skipped_if_env_is_set_to_a_true_value
+    ENV["SKIP_RECAPTCHA_VERIFY"] = "1"
+
+    assert @controller.verify_recaptcha()
+
+    ENV.delete("SKIP_RECAPTCHA_VERIFY")
+  end
+
+  def test_verify_does_not_get_skipped_if_env_is_set_to_0
+    ENV["SKIP_RECAPTCHA_VERIFY"] = "0"
+
+    assert !@controller.verify_recaptcha()
+
+    ENV.delete("SKIP_RECAPTCHA_VERIFY")
+  end
+
   private
 
   class TestController


### PR DESCRIPTION
We were wanting to do a performance test on a app this is running in a production environment. In order to be a able to test a page that has a captcha on it, the verification should be disabled for the duration of the performance test requests coming in. The most elegant solution seems to be to allow verification to be disabled by setting an ENV variable.

What I have implemented makes verify_recaptcha return true unless ENV["SKIP_RECAPTCHA_VERIFY"] is set (and not set to "0"). I also added two tests to check this behaviour.
