### PR TITLE
Add proxy authentication

### DIFF
--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -19,7 +19,7 @@ module Recaptcha
         recaptcha = nil
         if(Recaptcha.configuration.proxy)
           proxy_server = URI.parse(Recaptcha.configuration.proxy)
-          http = Net::HTTP::Proxy(proxy_server.host, proxy_server.port)
+          http = Net::HTTP::Proxy(proxy_server.host, proxy_server.port, proxy_server.user, proxy_server.password)
         else
           http = Net::HTTP
         end


### PR DESCRIPTION
Some proxies require authentication. User and password are optional attributes in proxy URL.

This change doesn't affect current behavior for proxies without authentication.

Example with authentication:

``` ruby
Recaptcha.configure do |config|
  config.public_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
  config.private_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
  config.proxy = 'http://user:pass@myrpoxy.com.au:8080'
end
```
