### PR TITLE
flash[:recptcha_error] = nil causes some problems in views

### DIFF
--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -42,7 +42,7 @@ module Recaptcha
           end
           return false
         else
-          flash[:recaptcha_error] = nil
+          flash.delete(:recaptcha_error)
           return true
         end
       rescue Timeout::Error


### PR DESCRIPTION
I have helper method, that iterates on flash this way: `flash.each { |key, msg| html << content_tag(:div, msg, :class => key) }`
The https://github.com/ambethia/recaptcha/blob/master/lib/recaptcha/verify.rb#L45 causes trouble in that case, because it adds key to flash hash. I suggest to `flash.delete(:recaptcha_error)` instead.
