### PR TITLE
Use i18n to humanize recaptcha errors.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -136,12 +136,19 @@ Some of the options available:
   end
 
 == I18n support
-reCAPTCHA passes two types of error explanation to a linked model. It will use the I18n gem 
-to translate the default error message if I18n is available. To customize the messages to your locale, 
+reCAPTCHA passes two types of error explanation to a linked model. It will use the I18n gem
+to translate the default error message if I18n is available. To customize the messages to your locale,
 add these keys to your I18n backend:
 
 <tt>recaptcha.errors.verification_failed</tt>:: error message displayed if the captcha words didn't match
 <tt>recaptcha.errors.recaptcha_unavailable</tt>:: displayed if a timout error occured while attempting to verify the captcha
+
+Also you can translate API response errors to human friendly by adding translations to the locale (+config/locales/en.yml+):
+
+  en:
+    recaptcha:
+      errors:
+        incorrect-captcha-sol: 'Fail'
 
 == TODO
 * Remove Rails/ActionController dependencies

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -34,10 +34,15 @@ module Recaptcha
         end
         answer, error = recaptcha.body.split.map { |s| s.chomp }
         unless answer == 'true'
-          flash[:recaptcha_error] = error
+          flash[:recaptcha_error] = if defined?(I18n)
+            I18n.translate("recaptcha.errors.#{error}", {:default => error})
+          else
+            error
+          end
+
           if model
             message = "Word verification response is incorrect, please try again."
-            message = I18n.translate(:'recaptcha.errors.verification_failed', {:default => message}) if defined?(I18n)
+            message = I18n.translate('recaptcha.errors.verification_failed', {:default => message}) if defined?(I18n)
             model.errors.add attribute, options[:message] || message
           end
           return false
@@ -46,10 +51,15 @@ module Recaptcha
           return true
         end
       rescue Timeout::Error
-        flash[:recaptcha_error] = "recaptcha-not-reachable"
+        flash[:recaptcha_error] = if defined?(I18n)
+          I18n.translate('recaptcha.errors.recaptcha_unreachable', {:default => 'Recaptcha unreachable.'})
+        else
+          'Recaptcha unreachable.'
+        end
+
         if model
           message = "Oops, we failed to validate your word verification response. Please try again."
-          message = I18n.translate(:'recaptcha.errors.recaptcha_unreachable', :default => message) if defined?(I18n)
+          message = I18n.translate('recaptcha.errors.recaptcha_unreachable', :default => message) if defined?(I18n)
           model.errors.add attribute, options[:message] || message
         end
         return false


### PR DESCRIPTION
I think it would be good if I could customize API error messages. I don't like to see 'incorrect-captcha-sol' in my flash message. What do you think if I18n do humanization for us? 
