### PR TITLE
Fixes localization for nonscript version and error expression

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -6,7 +6,7 @@ module Recaptcha
       # Default options
       key   = options[:public_key] ||= Recaptcha.configuration.public_key
       raise RecaptchaError, "No public key specified." unless key
-      error = options[:error] ||= (defined? flash ? flash[:recaptcha_error] : "")
+      error = options[:error] ||= ((defined? flash) ? flash[:recaptcha_error] : "")
       uri   = Recaptcha.configuration.api_server_url(options[:ssl])
       lang  = options[:display] && options[:display][:lang] ? options[:display][:lang].to_sym : ""
       html  = ""


### PR DESCRIPTION
## Localization for nonscript version

See https://github.com/ambethia/recaptcha/issues/21 issue
## error expression

For some reasons, this code:
`error = options[:error] ||= (defined? flash ? flash[:recaptcha_error] : "")`
returns "expression" for me instead of "incorrect-captcha-sol"

I've fixed this using brackets:
`error = options[:error] ||= ((defined? flash) ? flash[:recaptcha_error] : "")`

ruby - 1.9.2
rails -  3.2.1

Sorry for not providing tests. Hope it will be usefull.
