### PR TITLE
Use protocol-relative URL when :ssl is false

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -90,7 +90,7 @@ And, add +verify_recaptcha+ logic to each form action that you've protected.
 
 Some of the options available:
 
-<tt>:ssl</tt>::         Uses secure http for captcha widget (default +false+)
+<tt>:ssl</tt>::         Uses https for captcha widget, even if hosted on http (default +false+)
 <tt>:noscript</tt>::    Include <noscript> content (default +true+)
 <tt>:display</tt>::     Takes a hash containing the +theme+ and +tabindex+ options per the API. (default +nil+), options: 'red', 'white', 'blackglass', 'clean', 'custom'
 <tt>:ajax</tt>::        Render the dynamic AJAX captcha per the API. (default +false+)

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -3,7 +3,7 @@ require 'recaptcha/client_helper'
 require 'recaptcha/verify'
 
 module Recaptcha
-  RECAPTCHA_API_SERVER_URL        = 'http://www.google.com/recaptcha/api'
+  RECAPTCHA_API_SERVER_URL        = '//www.google.com/recaptcha/api'
   RECAPTCHA_API_SECURE_SERVER_URL = 'https://www.google.com/recaptcha/api'
   RECAPTCHA_VERIFY_URL            = 'http://www.google.com/recaptcha/api/verify'
 

--- a/test/recaptcha_test.rb
+++ b/test/recaptcha_test.rb
@@ -19,7 +19,7 @@ class RecaptchaClientHelperTest < Test::Unit::TestCase
 
   def test_recaptcha_tags
     # Might as well match something...
-    assert_match /http:\/\/www.google.com\/recaptcha\/api\/challenge/, recaptcha_tags
+    assert_match /"\/\/www.google.com\/recaptcha\/api\/challenge/, recaptcha_tags
   end
 
   def test_recaptcha_tags_with_ssl


### PR DESCRIPTION
I don't think anybody hosting on HTTPS would ever want to not use HTTPS
because using HTTP will display a nasty warning to the user. Setting
:ssl to true still works the same as before, but now setting :ssl to
false(or not setting it at all as false is the default) will still use
HTTPS when the page is hosted over HTTPS.

Fix for ambethia/recaptcha#70
