### PR TITLE
Render a fake recaptcha and add support to fail it when environment is skipped.

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -3,13 +3,28 @@ module Recaptcha
     # Your public API can be specified in the +options+ hash or preferably
     # using the Configuration.
     def recaptcha_tags(options = {})
+      html  = ""
+      env = options[:env] || ENV['RAILS_ENV']
+      if Recaptcha.configuration.skip_verify_env.include? env
+        html = <<-EOS
+          <div id="recaptcha_widget_div">
+            <div id="recaptcha_area" class="recaptcha_test">
+              <p>Recaptcha running on test mode.</p>
+              <p>Type "fail" on the field below to fail.</p>
+              <p>Type any other value to pass.</p>
+              <input name="recaptcha_response_field" id="recaptcha_response_field" type="text" autocorrect="off" autocapitalize="off" autocomplete="off">
+            </div>
+          </div>
+        EOS
+        return (html.respond_to?(:html_safe) && html.html_safe) || html
+      end
+
       # Default options
       key   = options[:public_key] ||= Recaptcha.configuration.public_key
       raise RecaptchaError, "No public key specified." unless key
       error = options[:error] ||= ((defined? flash) ? flash[:recaptcha_error] : "")
       uri   = Recaptcha.configuration.api_server_url(options[:ssl])
       lang  = options[:display] && options[:display][:lang] ? options[:display][:lang].to_sym : ""
-      html  = ""
       if options[:display]
         html << %{<script type="text/javascript">\n}
         html << %{  var RecaptchaOptions = #{options[:display].to_json};\n}

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -9,7 +9,7 @@ module Recaptcha
       end
 
       env = options[:env] || ENV['RAILS_ENV']
-      return true if Recaptcha.configuration.skip_verify_env.include? env
+      return params[:recaptcha_response_field] != "fail" if Recaptcha.configuration.skip_verify_env.include? env
       model = options[:model]
       attribute = options[:attribute] || :base
       private_key = options[:private_key] || Recaptcha.configuration.private_key


### PR DESCRIPTION
When the environment is skipped the recaptcha is still rendered.
In order to have a better test isolation and not contact any external service I've faked the recaptcha and added the possibility to fail the captcha when the environment is skipped.

This change does not alter the previous behavior it only adds the possibility to fail the captcha if we type "fail" in the recaptcha response field if the environment is skipped.
