### PR TITLE
Fix bug with theme and lang using together

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -12,7 +12,7 @@ module Recaptcha
       html  = ""
       if options[:display]
         html << %{<script type="text/javascript">\n}
-        html << %{  var RecaptchaOptions = #{hash_to_json(options[:display])};\n}
+        html << %{  var RecaptchaOptions = #{hash_to_json(options[:display].except(:lang))};\n}
         html << %{</script>\n}
       end
       if options[:ajax]


### PR DESCRIPTION
If using "recaptcha_tags display: { theme: 'white', lang: I18n.locale }" theme param not works and shown default (red).
With my fix it works good.