### PR TITLE
Update readme to prevent common installation error

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,7 +37,8 @@ into a +config/initializers/recaptcha.rb+ when used in a Rails project.
   Recaptcha.configure do |config|
     config.public_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
     config.private_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
-    config.proxy = 'http://myproxy.com.au:8080'
+    # Uncomment the following line if you are using a proxy server:
+    # config.proxy = 'http://myproxy.com.au:8080'
   end
 
 This way, you may also set additional options to fit recaptcha into your


### PR DESCRIPTION
To resolve the following error:
http://stackoverflow.com/questions/27094896/recaptcharecaptchaerror-in-registrationscontrollercreate/27316798
I've just commented out the proxy configuration line as most people don't use a proxy but DO blindly copy code from readme's (myself included! :)
