### PR TITLE
fix README config.api_version default value

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -39,9 +39,9 @@ into a +config/initializers/recaptcha.rb+ when used in a Rails project.
     config.private_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
     # Uncomment the following line if you are using a proxy server:
     # config.proxy = 'http://myproxy.com.au:8080'
-    # Uncomment if you want to use the newer version of the API,
-    # only works for versions >= 0.3.7:
-    # config.api_version = 'v2'
+    # Uncomment if you want to use the older version of the API,
+    # only works for versions >= 0.3.7, default value is 'v2':
+    # config.api_version = 'v1'
   end
 
 This way, you may also set additional options to fit recaptcha into your


### PR DESCRIPTION
According to <a href="https://github.com/ambethia/recaptcha/blob/master/lib/recaptcha.rb#L21" target="_blank">this</a>
```ruby
    RECAPTCHA_API_VERSION = 'v2' 
```
default value of config.api_version is 'v2', but README says the uncomment make sense.