### PR TITLE
Support for specifying custom response param

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Some of the options available:
 | :message     | Custom error message
 | :private_key | Your private API key, takes precedence over the ENV variable (default `nil`).
 | :timeout     | The number of seconds to wait for reCAPTCHA servers before give up. (default `3`)
+| :response    | Custom response parameter (default: params['g-recaptcha-response'])
 
 ```Ruby
 respond_to do |format|

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -12,6 +12,7 @@ module Recaptcha
       return true if Recaptcha::Verify.skip?(options[:env])
 
       private_key = options[:private_key] || Recaptcha.configuration.private_key!
+      recaptcha_response = options[:response] || params['g-recaptcha-response'].to_s
 
       begin
         # env['REMOTE_ADDR'] to retrieve IP for Grape API
@@ -19,7 +20,7 @@ module Recaptcha
         verify_hash = {
           "secret"    => private_key,
           "remoteip"  => remote_ip.to_s,
-          "response"  => params['g-recaptcha-response'].to_s
+          "response"  => recaptcha_response
         }
 
         reply = Recaptcha.get(verify_hash, options)


### PR DESCRIPTION
In cases when `recaptcha_tags` are not used, or at least not directly, it would bi nice to have option to set the response manually.