### PR TITLE
Update error messages for reCAPTCHA v2.0

### DIFF
--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -35,7 +35,7 @@ module Recaptcha
             attribute,
             options[:message],
             "recaptcha.errors.verification_failed",
-            "Word verification response is incorrect, please try again."
+            "reCAPTCHA verification failed, please try again."
           )
           false
         end
@@ -46,7 +46,7 @@ module Recaptcha
             attribute,
             options[:message],
             "recaptcha.errors.recaptcha_unreachable",
-            "Oops, we failed to validate your word verification response. Please try again."
+            "Oops, we failed to validate your reCAPTCHA response. Please try again."
           )
           false
         else

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -51,18 +51,18 @@ describe Recaptcha::Verify do
       expect_http_post.to_return(body: %{{"foo":"false", "bar":"invalid-site-private-key"}})
 
       refute @controller.verify_recaptcha
-      assert_equal "Word verification response is incorrect, please try again.", @controller.flash[:recaptcha_error]
+      assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
     it "adds an error to the model" do
       expect_http_post.to_return(body: %{{"foo":"false", "bar":"bad-news"}})
 
       errors = mock
-      errors.expects(:add).with(:base, "Word verification response is incorrect, please try again.")
+      errors.expects(:add).with(:base, "reCAPTCHA verification failed, please try again.")
       model = mock(:errors => errors)
 
       refute @controller.verify_recaptcha(:model => model)
-      assert_equal "Word verification response is incorrect, please try again.", @controller.flash[:recaptcha_error]
+      assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
     it "returns true on success with optional key" do
@@ -77,7 +77,7 @@ describe Recaptcha::Verify do
     it "fails silently when timing out" do
       expect_http_post.to_timeout
       refute @controller.verify_recaptcha
-      assert_equal "Oops, we failed to validate your word verification response. Please try again.", @controller.flash[:recaptcha_error]
+      assert_equal "Oops, we failed to validate your reCAPTCHA response. Please try again.", @controller.flash[:recaptcha_error]
     end
 
     it "blows up on timeout when graceful is disabled" do
@@ -93,7 +93,7 @@ describe Recaptcha::Verify do
     it "uses I18n for the failed message" do
       I18n.locale = :de
       verification_failed_translated   = "Sicherheitscode konnte nicht verifiziert werden."
-      verification_failed_default      = "Word verification response is incorrect, please try again."
+      verification_failed_default      = "reCAPTCHA verification failed, please try again."
 
       I18n.expects(:translate).with('recaptcha.errors.verification_failed', :default => verification_failed_default).returns(verification_failed_translated)
 
@@ -109,7 +109,7 @@ describe Recaptcha::Verify do
     it "uses I18n for the timeout message" do
       I18n.locale = :de
       recaptcha_unreachable_translated = "Netzwerkfehler, bitte versuchen Sie es später erneut."
-      recaptcha_unreachable_default    = "Oops, we failed to validate your word verification response. Please try again."
+      recaptcha_unreachable_default    = "Oops, we failed to validate your reCAPTCHA response. Please try again."
 
       I18n.expects(:translate).with('recaptcha.errors.recaptcha_unreachable', :default => recaptcha_unreachable_default).returns(recaptcha_unreachable_translated)
 
@@ -125,7 +125,7 @@ describe Recaptcha::Verify do
     it "translates api response with I18n" do
       api_error_translated = "Bad news, body :("
       expect_http_post.to_return(body: %{{"foo":"false", "bar":"bad-news"}})
-      I18n.expects(:translate).with('recaptcha.errors.verification_failed', :default => 'Word verification response is incorrect, please try again.').returns(api_error_translated)
+      I18n.expects(:translate).with('recaptcha.errors.verification_failed', :default => 'reCAPTCHA verification failed, please try again.').returns(api_error_translated)
 
       refute @controller.verify_recaptcha
       assert_equal api_error_translated, @controller.flash[:recaptcha_error]
@@ -135,7 +135,7 @@ describe Recaptcha::Verify do
       expect_http_post.to_return(body: %{{"foo":"false", "bar":"bad-news"}})
 
       refute @controller.verify_recaptcha
-      assert_equal "Word verification response is incorrect, please try again.", @controller.flash[:recaptcha_error]
+      assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
     it "does not flash error when request was not html" do


### PR DESCRIPTION
Error messages mentioning "Word verification" are no longer relevant with v2.0 so I suggest to replace them with more generic ones.