### PR TITLE
Clean up after with_configuration exception

### DIFF
--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -40,10 +40,9 @@ module Recaptcha
       configuration.send("#{key}=", value)
     end
 
-    result = yield if block_given?
-
+    yield if block_given?
+  ensure
     original_config.each { |key, value| configuration.send("#{key}=", value) }
-    result
   end
 
   def self.get(verify_hash, options)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -30,6 +30,21 @@ describe Recaptcha::Configuration do
     Recaptcha.configuration.public_key.must_equal outside
   end
 
+  it "cleans up block configuration after block raises an exception" do
+    outside = '0000000000000000000000000000000000000000'
+    Recaptcha.configuration.public_key.must_equal outside
+
+    begin
+      Recaptcha.with_configuration(public_key: '12345') do
+        Recaptcha.configuration.public_key.must_equal '12345'
+        raise "an exception"
+      end
+    rescue => e
+    end
+
+    Recaptcha.configuration.public_key.must_equal outside
+  end
+
   describe "#api_version=" do
     it "warns when assigning v2" do
       Recaptcha.configuration.expects(:warn)


### PR DESCRIPTION
If an exception is raised inside a `with_configuration` block, then the inner configuration "leaks" outside the block. This PR ensures that the cleanup always takes place.