### PR TITLE
Provides clearer message with action for recaptcha_tags

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -3,8 +3,10 @@ module Recaptcha
     # Your public API can be specified in the +options+ hash or preferably
     # using the Configuration.
     def recaptcha_tags(options = {})
-      raise(RecaptchaError, "Secure Token is deprecated.") if options.key?(:stoken)
-      raise(RecaptchaError, "SSL is always true.") if options.key?(:ssl)
+      raise(RecaptchaError, "Secure Token is deprecated. Please remove 'stoken' from your calls to recaptcha_tags.") if
+          options.key?(:stoken)
+      raise(RecaptchaError, "SSL is now always true. Please remove 'ssl' from your calls to recaptcha_tags.") if options
+                                                                                                                 .key?(:ssl)
       public_key = options[:public_key] || Recaptcha.configuration.public_key!
 
       script_url = Recaptcha.configuration.api_server_url


### PR DESCRIPTION
After a recent upgrade I was getting `SSL is always true` all over my Rails 5 feature specs but had no idea what was causing it and how to fix it. I think this clearer error message gives users an action to take to fix it.