### PR TITLE
Unfreeze SKIP_VERIFY_ENV array

### DIFF
--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -12,7 +12,6 @@ module Recaptcha
 
   USE_SSL_BY_DEFAULT              = false
   HANDLE_TIMEOUTS_GRACEFULLY      = true
-  SKIP_VERIFY_ENV = ['test', 'cucumber']
   DEFAULT_TIMEOUT = 3
 
   # Gives access to the current Configuration.

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -12,7 +12,7 @@ module Recaptcha
 
   USE_SSL_BY_DEFAULT              = false
   HANDLE_TIMEOUTS_GRACEFULLY      = true
-  SKIP_VERIFY_ENV = ['test', 'cucumber'].freeze
+  SKIP_VERIFY_ENV = ['test', 'cucumber']
   DEFAULT_TIMEOUT = 3
 
   # Gives access to the current Configuration.

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -31,7 +31,7 @@ module Recaptcha
     attr_accessor :skip_verify_env, :private_key, :public_key, :proxy, :handle_timeouts_gracefully, :hostname
 
     def initialize #:nodoc:
-      @skip_verify_env            = SKIP_VERIFY_ENV
+      @skip_verify_env            = %w(test cucumber)
       @handle_timeouts_gracefully = HANDLE_TIMEOUTS_GRACEFULLY
 
       @private_key           = ENV['RECAPTCHA_PRIVATE_KEY']

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -31,7 +31,7 @@ module Recaptcha
     attr_accessor :skip_verify_env, :private_key, :public_key, :proxy, :handle_timeouts_gracefully, :hostname
 
     def initialize #:nodoc:
-      @skip_verify_env            = %w(test cucumber)
+      @skip_verify_env            = %w[test cucumber]
       @handle_timeouts_gracefully = HANDLE_TIMEOUTS_GRACEFULLY
 
       @private_key           = ENV['RECAPTCHA_PRIVATE_KEY']


### PR DESCRIPTION
Currently there is an error ```can't modify frozen Array``` when you try to delete ```test``` from ```SKIP_VERIFY_ENV``` array( ```Recaptcha.configuration.skip_verify_env.delete('test')``` ) while testing.