### PR TITLE
Update fallback HTML

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -34,23 +34,24 @@ module Recaptcha
       if options[:noscript] != false
         html << <<-HTML
           <noscript>
-            <div style="width: 302px; height: 352px;">
-              <div style="width: 302px; height: 352px; position: relative;">
-                <div style="width: 302px; height: 352px; position: absolute;">
+            <div>
+              <div style="width: 302px; height: 422px; position: relative;">
+                <div style="width: 302px; height: 422px; position: absolute;">
                   <iframe
                     src="#{fallback_uri}"
                     frameborder="0" scrolling="no"
-                    style="width: 302px; height:352px; border-style: none;">
+                    style="width: 302px; height:422px; border-style: none;">
                   </iframe>
                 </div>
-                <div style="width: 250px; height: 80px; position: absolute; border-style: none;
-                  bottom: 21px; left: 25px; margin: 0px; padding: 0px; right: 25px;">
-                  <textarea id="g-recaptcha-response" name="g-recaptcha-response"
-                    class="g-recaptcha-response"
-                    style="width: 250px; height: 80px; border: 1px solid #c1c1c1;
-                    margin: 0px; padding: 0px; resize: none;" value="">
-                  </textarea>
-                </div>
+              </div>
+              <div style="width: 300px; height: 60px; border-style: none;
+                bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px;
+                background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">
+                <textarea id="g-recaptcha-response" name="g-recaptcha-response"
+                  class="g-recaptcha-response"
+                  style="width: 250px; height: 40px; border: 1px solid #c1c1c1;
+                  margin: 10px 25px; padding: 0px; resize: none;" value="">
+                </textarea>
               </div>
             </div>
           </noscript>


### PR DESCRIPTION
reCaptcha [documentation](https://developers.google.com/recaptcha/docs/faq#does-recaptcha-support-users-that-dont-have-javascript-enabled) provides a different fallback HTML version for the `<noscript>` tag, it was probably updated recently and it is causing the fallback iframe to not render properly.