### PR TITLE
Rename api keys to v2 scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Set in production and locally use [dotenv](https://github.com/bkeepers/dotenv), 
 Otherwise see [Alternative API key setup](#alternative-api-key-setup).
 
 ```
-export RECAPTCHA_PUBLIC_KEY  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
-export RECAPTCHA_PRIVATE_KEY = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+export RECAPTCHA_SITE_KEY  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
+export RECAPTCHA_SECRET_KEY = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
 ```
 
 Add `recaptcha_tags` to the forms you want to protect.
@@ -69,7 +69,7 @@ Some of the options available:
 | :noscript   | Include <noscript> content (default `true`)|
 | :display    | Takes a hash containing the `theme` and `tabindex` options per the API. (default `nil`), options: 'red', 'white', 'blackglass', 'clean', 'custom'|
 | :ajax       | Render the dynamic AJAX captcha per the API. (default `false`)|
-| :public_key | Override public API key |
+| :site_key   | Override site API key |
 | :error      | Override the error code returned from the reCAPTCHA API (default `nil`)|
 | :size       | Specify a size (default `nil`)|
 | :hl         | Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. (See [language codes](https://developers.google.com/recaptcha/docs/language)) |
@@ -93,7 +93,7 @@ Some of the options available:
 | :model       | Model to set errors.
 | :attribute   | Model attribute to receive errors. (default :base)
 | :message     | Custom error message.
-| :private_key | Override private API key.
+| :secret_key  | Override secret API key.
 | :timeout     | The number of seconds to wait for reCAPTCHA servers before give up. (default `3`)
 | :response    | Custom response parameter. (default: params['g-recaptcha-response'])
 | :hostname    | Expected hostname or a callable that validates the hostname, see [domain validation](https://developers.google.com/recaptcha/docs/domain_validation) and [hostname](https://developers.google.com/recaptcha/docs/verify#api-response) docs. (default: `nil`, but can be changed by setting `config.hostname`)
@@ -131,8 +131,8 @@ Recaptcha.configuration.skip_verify_env.delete("test")
 ```Ruby
 # config/initializers/recaptcha.rb
 Recaptcha.configure do |config|
-  config.public_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
-  config.private_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+  config.site_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
+  config.secret_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
   # Uncomment the following line if you are using a proxy server:
   # config.proxy = 'http://myproxy.com.au:8080'
 end
@@ -143,8 +143,8 @@ end
 For temporary overwrites (not thread safe).
 
 ```Ruby
-Recaptcha.with_configuration(public_key: '12345') do
-  # Do stuff with the overwritten public_key.
+Recaptcha.with_configuration(site_key: '12345') do
+  # Do stuff with the overwritten site_key.
 end
 ```
 
@@ -153,11 +153,11 @@ end
 Pass in keys as options at runtime, for code base with multiple reCAPTCHA setups:
 
 ```Ruby
-recaptcha_tags public_key: '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
+recaptcha_tags site_key: '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
 
 and
 
-verify_recaptcha private_key: '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+verify_recaptcha secret_key: '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
 ```
 
 ## Misc

--- a/demo/rails/app/views/captcha/index.html.erb
+++ b/demo/rails/app/views/captcha/index.html.erb
@@ -9,14 +9,14 @@
       // Renders the HTML element with id 'example1' as a reCAPTCHA widget.
       // The id of the reCAPTCHA widget is assigned to 'widgetId1'.
       widgetId1 = grecaptcha.render('example1', {
-        'sitekey' : "<%= Recaptcha.configuration.public_key %>",
+        'sitekey' : "<%= Recaptcha.configuration.site_key %>",
         'theme' : 'light'
       });
       widgetId2 = grecaptcha.render(document.getElementById('example2'), {
-        'sitekey' : "<%= Recaptcha.configuration.public_key %>"
+        'sitekey' : "<%= Recaptcha.configuration.site_key %>"
       });
       grecaptcha.render('example3', {
-        'sitekey' : "<%= Recaptcha.configuration.public_key %>",
+        'sitekey' : "<%= Recaptcha.configuration.site_key %>",
         'callback' : verifyCallback,
         'theme' : 'dark'
       });

--- a/demo/sinatra/server.rb
+++ b/demo/sinatra/server.rb
@@ -4,8 +4,8 @@ require 'recaptcha'
 
 # these will only work on localhost ... make your own at https://www.google.com/recaptcha
 Recaptcha.configure do |config|
-  config.public_key  = '6Le7oRETAAAAAETt105rjswZ15EuVJiF7BxPROkY'
-  config.private_key = '6Le7oRETAAAAAL5a8yOmEdmDi3b2pH7mq5iH1bYK'
+  config.site_key  = '6Le7oRETAAAAAETt105rjswZ15EuVJiF7BxPROkY'
+  config.secret_key = '6Le7oRETAAAAAL5a8yOmEdmDi3b2pH7mq5iH1bYK'
 end
 
 include Recaptcha::ClientHelper

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -10,17 +10,17 @@ module Recaptcha
         raise(RecaptchaError, "SSL is now always true. Please remove 'ssl' from your calls to recaptcha_tags.")
       end
 
-      public_key = options[:public_key] || Recaptcha.configuration.public_key!
+      site_key = options[:site_key] || Recaptcha.configuration.site_key!
 
       script_url = Recaptcha.configuration.api_server_url
       script_url += "?hl=#{options[:hl]}" unless options[:hl].to_s == ""
-      fallback_uri = "#{script_url.chomp('.js')}/fallback?k=#{public_key}"
+      fallback_uri = "#{script_url.chomp('.js')}/fallback?k=#{site_key}"
 
       data_attributes = [:theme, :type, :callback, :expired_callback, :size]
       data_attributes = options.each_with_object({}) do |(k, v), a|
         a[k] = v if data_attributes.include?(k)
       end
-      data_attributes[:sitekey] = public_key
+      data_attributes[:sitekey] = site_key
       tag_attributes = data_attributes.map { |k, v| %(data-#{k.to_s.tr('_', '-')}="#{v}") }.join(" ")
 
       if id = options[:id]

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -15,7 +15,7 @@ module Recaptcha
   # Your are able to customize all attributes listed below. All values have
   # sensitive default and will very likely not need to be changed.
   #
-  # Please note that the public and private key for the reCAPTCHA API Access
+  # Please note that the site and secret key for the reCAPTCHA API Access
   # have no useful default value. The keys may be set via the Shell enviroment
   # or using this configuration. Settings within this configuration always take
   # precedence.
@@ -23,27 +23,27 @@ module Recaptcha
   # Setting the keys with this Configuration
   #
   #   Recaptcha.configure do |config|
-  #     config.public_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
-  #     config.private_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+  #     config.site_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
+  #     config.secret_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
   #   end
   #
   class Configuration
-    attr_accessor :skip_verify_env, :private_key, :public_key, :proxy, :handle_timeouts_gracefully, :hostname
+    attr_accessor :skip_verify_env, :secret_key, :site_key, :proxy, :handle_timeouts_gracefully, :hostname
 
     def initialize #:nodoc:
       @skip_verify_env            = %w[test cucumber]
       @handle_timeouts_gracefully = HANDLE_TIMEOUTS_GRACEFULLY
 
-      @private_key           = ENV['RECAPTCHA_PRIVATE_KEY']
-      @public_key            = ENV['RECAPTCHA_PUBLIC_KEY']
+      @secret_key           = ENV['RECAPTCHA_SECRET_KEY']
+      @site_key             = ENV['RECAPTCHA_SITE_KEY']
     end
 
-    def private_key!
-      private_key || raise(RecaptchaError, "No private key specified.")
+    def secret_key!
+      secret_key || raise(RecaptchaError, "No secret key specified.")
     end
 
-    def public_key!
-      public_key || raise(RecaptchaError, "No public key specified.")
+    def site_key!
+      site_key || raise(RecaptchaError, "No site key specified.")
     end
 
     def api_server_url

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -62,11 +62,11 @@ module Recaptcha
     private
 
     def recaptcha_verify_via_api_call(request, recaptcha_response, options)
-      private_key = options[:private_key] || Recaptcha.configuration.private_key!
+      secret_key = options[:secret_key] || Recaptcha.configuration.secret_key!
       remote_ip = (request.respond_to?(:remote_ip) && request.remote_ip) || (env && env['REMOTE_ADDR'])
 
       verify_hash = {
-        "secret"    => private_key,
+        "secret"    => secret_key,
         "remoteip"  => remote_ip.to_s,
         "response"  => recaptcha_response
       }

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -26,8 +26,8 @@ describe Recaptcha::ClientHelper do
     )
   end
 
-  it "raises withut public key" do
-    Recaptcha.configuration.public_key = nil
+  it "raises withut site key" do
+    Recaptcha.configuration.site_key = nil
     assert_raises Recaptcha::RecaptchaError do
       recaptcha_tags
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -9,25 +9,25 @@ describe Recaptcha::Configuration do
 
   it "can overwrite configuration in a block" do
     outside = '0000000000000000000000000000000000000000'
-    Recaptcha.configuration.public_key.must_equal outside
+    Recaptcha.configuration.site_key.must_equal outside
 
-    Recaptcha.with_configuration(public_key: '12345') do
-      Recaptcha.configuration.public_key.must_equal '12345'
+    Recaptcha.with_configuration(site_key: '12345') do
+      Recaptcha.configuration.site_key.must_equal '12345'
     end
 
-    Recaptcha.configuration.public_key.must_equal outside
+    Recaptcha.configuration.site_key.must_equal outside
   end
 
   it "cleans up block configuration after block raises an exception" do
-    before = Recaptcha.configuration.public_key.dup
+    before = Recaptcha.configuration.site_key.dup
 
     assert_raises NoMemoryError do
-      Recaptcha.with_configuration(public_key: '12345') do
-        Recaptcha.configuration.public_key.must_equal '12345'
+      Recaptcha.with_configuration(site_key: '12345') do
+        Recaptcha.configuration.site_key.must_equal '12345'
         raise NoMemoryError, "an exception"
       end
     end
 
-    Recaptcha.configuration.public_key.must_equal before
+    Recaptcha.configuration.site_key.must_equal before
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,8 +15,8 @@ Minitest::Test.send(:prepend, Module.new do
   def setup
     super
     Recaptcha.configure do |config|
-      config.public_key = '0000000000000000000000000000000000000000'
-      config.private_key = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      config.site_key = '0000000000000000000000000000000000000000'
+      config.secret_key = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
     end
   end
 end)

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -10,7 +10,7 @@ describe Recaptcha::Verify do
     @expected_post_data["response"]   = "response"
 
     @controller.params = {:recaptcha_response_field => "response", 'g-recaptcha-response' => 'string'}
-    @expected_post_data["secret"] = Recaptcha.configuration.private_key
+    @expected_post_data["secret"] = Recaptcha.configuration.secret_key
 
     @expected_uri = URI.parse(Recaptcha.configuration.verify_url)
   end
@@ -40,15 +40,15 @@ describe Recaptcha::Verify do
       assert_nil @controller.flash[:recaptcha_error]
     end
 
-    it "raises without private key" do
-      Recaptcha.configuration.private_key = nil
+    it "raises without secret key" do
+      Recaptcha.configuration.secret_key = nil
       assert_raises Recaptcha::RecaptchaError do
         @controller.verify_recaptcha
       end
     end
 
-    it "returns false when private key is invalid" do
-      expect_http_post.to_return(body: %({"foo":"false", "bar":"invalid-site-private-key"}))
+    it "returns false when secret key is invalid" do
+      expect_http_post.to_return(body: %({"foo":"false", "bar":"invalid-site-secret-key"}))
 
       refute @controller.verify_recaptcha
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
@@ -68,9 +68,9 @@ describe Recaptcha::Verify do
     it "returns true on success with optional key" do
       key = 'ADIFFERENTPRIVATEKEYXXXXXXXXXXXXXX'
       @controller.flash[:recaptcha_error] = "previous error that should be cleared"
-      expect_http_post(private_key: key).to_return(body: '{"success":true}')
+      expect_http_post(secret_key: key).to_return(body: '{"success":true}')
 
-      assert @controller.verify_recaptcha(private_key: key)
+      assert @controller.verify_recaptcha(secret_key: key)
       assert_nil @controller.flash[:recaptcha_error]
     end
 
@@ -241,10 +241,10 @@ describe Recaptcha::Verify do
     end
   end
 
-  def expect_http_post(private_key: Recaptcha.configuration.private_key)
+  def expect_http_post(secret_key: Recaptcha.configuration.secret_key)
     stub_request(
       :get,
-      "https://www.google.com/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{private_key}"
+      "https://www.google.com/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{secret_key}"
     )
   end
 end


### PR DESCRIPTION
The Recaptcha v2 API uses the names site_key / secret_key instead of public_key
/ private_key. Make the code reflect this change.