### PR TITLE
[DONE] Show theme option instead of display on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Some of the options available:
 | Option      | Description |
 |-------------|-------------|
 | :noscript   | Include <noscript> content (default `true`)|
-| :display    | Takes a hash containing the `theme` and `tabindex` options per the API. (default `nil`), options: 'red', 'white', 'blackglass', 'clean', 'custom'|
+| :theme      | Specify the theme to be used per the API. Available options: `dark` and `light`. (default `light`)|
 | :ajax       | Render the dynamic AJAX captcha per the API. (default `false`)|
 | :site_key   | Override site API key |
 | :error      | Override the error code returned from the reCAPTCHA API (default `nil`)|


### PR DESCRIPTION
## Description

The PR came while trying to select a different theme for reCaptcha newest version (v2.0).

The reported problem was found while searching through [`client_helper.rb`](https://github.com/ambethia/recaptcha/blob/master/lib/recaptcha/client_helper.rb#L19-L22) and after trying to set the theme like this:

```erb
<%= recaptcha_tags default: { theme: 'blackglass' } %>
```

To make it work I had set theme as below and using [Google's reference for display](https://developers.google.com/recaptcha/docs/display):

```erb
<%= recaptcha_tags theme: 'dark' %>
```

## To be done

- [x] Replace `display` for `theme` on readme
- [x] Expose the permitted values on readme