### PR TITLE
Add invisible reCAPTCHA support

### DIFF
--- a/demo/rails/.env
+++ b/demo/rails/.env
@@ -1,3 +1,4 @@
-# reCAPTCHA keys for testing purposes (https://developers.google.com/recaptcha/docs/faq)
-RECAPTCHA_SITE_KEY = 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
-RECAPTCHA_SECRET_KEY = 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+# reCAPTCHA keys for testing purposes
+# Make your own at https://www.google.com/recaptcha
+RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/demo/rails/.env
+++ b/demo/rails/.env
@@ -1,3 +1,3 @@
-# these will only work on localhost (registered on mg@z) ... make your own at https://www.google.com/recaptcha
-RECAPTCHA_PUBLIC_KEY=6Le7oRETAAAAAETt105rjswZ15EuVJiF7BxPROkY
-RECAPTCHA_PRIVATE_KEY=6Le7oRETAAAAAL5a8yOmEdmDi3b2pH7mq5iH1bYK
+# reCAPTCHA keys for testing purposes (https://developers.google.com/recaptcha/docs/faq)
+RECAPTCHA_SITE_KEY = 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+RECAPTCHA_SECRET_KEY = 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/demo/rails/app/views/captcha/index.html.erb
+++ b/demo/rails/app/views/captcha/index.html.erb
@@ -38,7 +38,7 @@
   <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
 <% elsif params[:invisible] %>
   <script>
-    function onSubmitCallback() {
+    var onSubmitCallback = function() {
       document.getElementById("invisible-recaptcha-form").submit();
     }
   </script>

--- a/demo/rails/app/views/captcha/index.html.erb
+++ b/demo/rails/app/views/captcha/index.html.erb
@@ -43,7 +43,7 @@
     }
   </script>
   <%= form_tag "/captchas", id: "invisible-recaptcha-form" do %>
-    <%= invisible_recaptcha_tags callback: 'onSubmitCallback' %>
+    <%= invisible_recaptcha_tags callback: 'onSubmitCallback', text: 'Save changes' %>
   <% end %>
 <% else %>
   <%= form_tag "/captchas" do %>

--- a/demo/rails/app/views/captcha/index.html.erb
+++ b/demo/rails/app/views/captcha/index.html.erb
@@ -36,11 +36,21 @@
     <%= submit_tag %>
   <% end %>
   <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
-  <%= link_to 'Single ?', '?' %>
+<% elsif params[:invisible] %>
+  <script>
+    function onSubmitCallback() {
+      document.getElementById("invisible-recaptcha-form").submit();
+    }
+  </script>
+  <%= form_tag "/captchas", id: "invisible-recaptcha-form" do %>
+    <%= invisible_recaptcha_tags callback: 'onSubmitCallback' %>
+  <% end %>
 <% else %>
   <%= form_tag "/captchas" do %>
     <%= recaptcha_tags %>
     <%= submit_tag %>
   <% end %>
-  <%= link_to 'Multi ?', '?multi=1' %>
 <% end %>
+<%= link_to 'Single ?', '?' if params[:multi] or params[:invisible] %>
+<%= link_to 'Multi ?', '?multi=1' unless params[:multi] %>
+<%= link_to 'Invisible ?', '?invisible=1' unless params[:invisible] %>

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -19,11 +19,10 @@ module Recaptcha
 
       html = ""
       html << %(<script src="#{script_url}" async defer></script>\n) if options.fetch(:script, true)
-      html
 
       fallback_uri = "#{script_url.chomp('.js')}/fallback?k=#{site_key}"
 
-      return html, tag_attributes, fallback_uri
+      [html, tag_attributes, fallback_uri]
     end
 
     # Your public API can be specified in the +options+ hash or preferably

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -60,5 +60,25 @@ module Recaptcha
 
       html.respond_to?(:html_safe) ? html.html_safe : html
     end
+
+    # Invisible reCAPTCHA implementation
+    def invisible_recaptcha_tags(options = {})
+      site_key = options[:site_key] || Recaptcha.configuration.site_key!
+      script_url = Recaptcha.configuration.api_server_url
+      data_attributes = [:badge, :theme, :type, :callback, :expired_callback, :size, :tabindex]
+      data_attributes = options.each_with_object({}) do |(k, v), a|
+        a[k] = v if data_attributes.include?(k)
+      end
+      data_attributes[:sitekey] = site_key
+      tag_attributes = data_attributes.map { |k, v| %(data-#{k.to_s.tr('_', '-')}="#{v}") }.join(" ")
+      if id = options[:id]
+        tag_attributes << %( id="#{id}")
+      end
+      class_ = options[:class]
+      html = ""
+      html << %(<script src="#{script_url}" async defer></script>\n) if options.fetch(:script, true)
+      html << %(<button type="submit" class="g-recaptcha #{class_}" #{tag_attributes}>Submit</button>\n)
+      html.respond_to?(:html_safe) ? html.html_safe : html
+    end
   end
 end

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -1,5 +1,31 @@
 module Recaptcha
   module ClientHelper
+    def build_html(options = {})
+      site_key = options[:site_key] || Recaptcha.configuration.site_key!
+      script_url = Recaptcha.configuration.api_server_url
+      script_url += "?hl=#{options[:hl]}" unless options[:hl].to_s == ""
+
+      data_attributes = [:badge, :theme, :type, :callback, :expired_callback, :size]
+      data_attributes = options.each_with_object({}) do |(k, v), a|
+        a[k] = v if data_attributes.include?(k)
+      end
+      data_attributes[:sitekey] = site_key
+
+      tag_attributes = data_attributes.map { |k, v| %(data-#{k.to_s.tr('_', '-')}="#{v}") }.join(" ")
+      if id = options[:id]
+        tag_attributes << %( id="#{id}")
+      end
+      tag_attributes << %( class="g-recaptcha #{options[:class]}")
+
+      html = ""
+      html << %(<script src="#{script_url}" async defer></script>\n) if options.fetch(:script, true)
+      html
+
+      fallback_uri = "#{script_url.chomp('.js')}/fallback?k=#{site_key}"
+
+      return html, tag_attributes, fallback_uri
+    end
+
     # Your public API can be specified in the +options+ hash or preferably
     # using the Configuration.
     def recaptcha_tags(options = {})
@@ -10,26 +36,8 @@ module Recaptcha
         raise(RecaptchaError, "SSL is now always true. Please remove 'ssl' from your calls to recaptcha_tags.")
       end
 
-      site_key = options[:site_key] || Recaptcha.configuration.site_key!
-
-      script_url = Recaptcha.configuration.api_server_url
-      script_url += "?hl=#{options[:hl]}" unless options[:hl].to_s == ""
-      fallback_uri = "#{script_url.chomp('.js')}/fallback?k=#{site_key}"
-
-      data_attributes = [:badge, :theme, :type, :callback, :expired_callback, :size]
-      data_attributes = options.each_with_object({}) do |(k, v), a|
-        a[k] = v if data_attributes.include?(k)
-      end
-      data_attributes[:sitekey] = site_key
-      tag_attributes = data_attributes.map { |k, v| %(data-#{k.to_s.tr('_', '-')}="#{v}") }.join(" ")
-
-      if id = options[:id]
-        tag_attributes << %( id="#{id}")
-      end
-
-      html = ""
-      html << %(<script src="#{script_url}" async defer></script>\n) if options.fetch(:script, true)
-      html << %(<div class="g-recaptcha" #{tag_attributes}></div>\n)
+      html, tag_attributes, fallback_uri = build_html(options)
+      html << %(<div #{tag_attributes}></div>\n)
 
       if options[:noscript] != false
         html << <<-HTML
@@ -63,21 +71,8 @@ module Recaptcha
 
     # Invisible reCAPTCHA implementation
     def invisible_recaptcha_tags(options = {})
-      site_key = options[:site_key] || Recaptcha.configuration.site_key!
-      script_url = Recaptcha.configuration.api_server_url
-      data_attributes = [:badge, :theme, :type, :callback, :expired_callback, :size, :tabindex]
-      data_attributes = options.each_with_object({}) do |(k, v), a|
-        a[k] = v if data_attributes.include?(k)
-      end
-      data_attributes[:sitekey] = site_key
-      tag_attributes = data_attributes.map { |k, v| %(data-#{k.to_s.tr('_', '-')}="#{v}") }.join(" ")
-      if id = options[:id]
-        tag_attributes << %( id="#{id}")
-      end
-      class_ = options[:class]
-      html = ""
-      html << %(<script src="#{script_url}" async defer></script>\n) if options.fetch(:script, true)
-      html << %(<button type="submit" class="g-recaptcha #{class_}" #{tag_attributes}>Submit</button>\n)
+      html, tag_attributes = build_html(options)
+      html << %(<button type="submit" #{tag_attributes}>#{options[:button_text]}</button>\n)
       html.respond_to?(:html_safe) ? html.html_safe : html
     end
   end

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -72,7 +72,7 @@ module Recaptcha
     # Invisible reCAPTCHA implementation
     def invisible_recaptcha_tags(options = {})
       html, tag_attributes = build_html(options)
-      html << %(<button type="submit" #{tag_attributes}>#{options[:button_text]}</button>\n)
+      html << %(<button type="submit" #{tag_attributes}>#{options[:text]}</button>\n)
       html.respond_to?(:html_safe) ? html.html_safe : html
     end
   end

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -10,7 +10,7 @@ describe Recaptcha::ClientHelper do
   end
 
   describe "noscript" do
-    it "does not adds noscript tags when noscript is given" do
+    it "does not add noscript tags when noscript is given" do
       recaptcha_tags(noscript: false).wont_include "noscript"
     end
 
@@ -26,7 +26,7 @@ describe Recaptcha::ClientHelper do
     )
   end
 
-  it "raises withut site key" do
+  it "raises without site key" do
     Recaptcha.configuration.site_key = nil
     assert_raises Recaptcha::RecaptchaError do
       recaptcha_tags
@@ -45,5 +45,32 @@ describe Recaptcha::ClientHelper do
     html.wont_include(
       "<script"
     )
+  end
+
+  describe "invisible recatpcha" do
+    it "uses ssl" do
+      invisible_recaptcha_tags.must_include "\"#{Recaptcha.configuration.api_server_url}\""
+    end
+
+    it "raises without site key" do
+      Recaptcha.configuration.site_key = nil
+      assert_raises Recaptcha::RecaptchaError do
+        invisible_recaptcha_tags
+      end
+    end
+
+    it "includes id as button attribute" do
+      html = invisible_recaptcha_tags(id: 'my_id')
+      html.must_include(
+        " id=\"my_id\""
+      )
+    end
+
+    it "does not include <script> tag when setting script: false" do
+      html = invisible_recaptcha_tags(script: false)
+      html.wont_include(
+        "<script"
+      )
+    end
   end
 end

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -21,9 +21,7 @@ describe Recaptcha::ClientHelper do
 
   it "can include size" do
     html = recaptcha_tags(size: 10)
-    html.must_include(
-      "<div class=\"g-recaptcha\" data-size=\"10\" data-sitekey=\"0000000000000000000000000000000000000000\""
-    )
+    html.must_include("data-size=\"10\"")
   end
 
   it "raises without site key" do
@@ -35,16 +33,12 @@ describe Recaptcha::ClientHelper do
 
   it "includes id as div attribute" do
     html = recaptcha_tags(id: 'my_id')
-    html.must_include(
-      " id=\"my_id\""
-    )
+    html.must_include(" id=\"my_id\"")
   end
 
   it "does not include <script> tag when setting script: false" do
     html = recaptcha_tags(script: false)
-    html.wont_include(
-      "<script"
-    )
+    html.wont_include("<script")
   end
 
   describe "invisible recatpcha" do
@@ -61,16 +55,12 @@ describe Recaptcha::ClientHelper do
 
     it "includes id as button attribute" do
       html = invisible_recaptcha_tags(id: 'my_id')
-      html.must_include(
-        " id=\"my_id\""
-      )
+      html.must_include(" id=\"my_id\"")
     end
 
     it "does not include <script> tag when setting script: false" do
       html = invisible_recaptcha_tags(script: false)
-      html.wont_include(
-        "<script"
-      )
+      html.wont_include("<script")
     end
   end
 end


### PR DESCRIPTION
This pull request adds preliminary support for the [invisible reCAPTCHA](https://developers.google.com/recaptcha/docs/invisible).

It introduces the `invisible_recaptcha_tags` helper, which adds reCAPTCHA's JavaScript resource as well as a submit button. The user also needs to set a callback to handle competition of the captcha using the `callback` option.

More info: https://developers.google.com/recaptcha/docs/invisible#auto_render