### PR TITLE
Document `invisible_recaptcha_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,44 @@ Some of the options available:
 | :hostname    | Expected hostname or a callable that validates the hostname, see [domain validation](https://developers.google.com/recaptcha/docs/domain_validation) and [hostname](https://developers.google.com/recaptcha/docs/verify#api-response) docs. (default: `nil`, but can be changed by setting `config.hostname`)
 | :env         | Current environment. The request to verify will be skipped if the environment is specified in configuration under `skip_verify_env`
 
+## invisible_recaptcha_tags
+Since 4.1.0, this gem supports [Invisible reCAPTCHA](https://developers.google.com/recaptcha/docs/invisible). Unlike `recaptcha_tags`, `invisible_recaptcha_tags` has two major differences in implementation:
+
+1. You must specify a callback function, which would be called after verification with Google's reCAPTCHA service. Ideally, this callback function would submit the actual form.
+2. The `invisible_recaptcha_tags` will generate a submit button for you. You should not need to add a `f.submit` or `submit_tag` to your form.
+
+Here is an example in Rails:
+
+First, add `invisible_recaptcha_tags` to your form and specify a callback name. Also, be sure to specify an id or some kind of identifier for your form. In this example, the callback is "submitInvisibleRecaptchaForm" and the id is "invisible-recaptcha-form".
+
+```Erb
+<%= form_for @foo, html: {id: 'invisible-recaptcha-form'} do |f| %>
+  # ... other tags
+  <%= invisible_recaptcha_tags, callback: 'submitInvisibleRecaptchaForm' %>
+<% end %>
+```
+
+Then, in your javascript, create a function that would submit the form. This function name should be the same name as specified in the callback.
+
+```Javascript
+// app/assets/javascripts/application.js
+var submitInvisibleRecaptchaForm = function () {
+  document.getElementById("invisible-recaptcha-form").submit();
+};
+```
+
+Finally, add `verify_recaptcha` to your controller action.
+
+```Ruby
+# app/controllers/foos_controller.rb
+@foo = Foo.new(params[:foo].permit(:name))
+if verify_recaptcha(model: @foo) && @foo.save
+  redirect_to @foo
+else
+  render 'new'
+end
+```
+
 ## I18n support
 reCAPTCHA passes two types of error explanation to a linked model. It will use the I18n gem
 to translate the default error message if I18n is available. To customize the messages to your locale,


### PR DESCRIPTION
This adds usage example for `invisible_recaptcha_tags` to the readme.
`invisible_recaptcha_tags` was originally implemented in #211 by
@juampi and released in 4.1.0.

I found #211 to be useful for what I needed, so I decided to document a
usage example to help others. Please let me know if anything needs to
be corrected.