### PR TITLE
Make api_server_url and verify_url configurable

### DIFF
--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -37,9 +37,6 @@ module Recaptcha
 
       @secret_key           = ENV['RECAPTCHA_SECRET_KEY']
       @site_key             = ENV['RECAPTCHA_SITE_KEY']
-
-      @api_server_url       = ENV['RECAPTCHA_API_SERVER_URL']
-      @verify_url           = ENV['RECAPTCHA_VERIFY_URL']
     end
 
     def secret_key!

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -28,7 +28,8 @@ module Recaptcha
   #   end
   #
   class Configuration
-    attr_accessor :skip_verify_env, :secret_key, :site_key, :proxy, :handle_timeouts_gracefully, :hostname
+    attr_accessor :skip_verify_env, :secret_key, :site_key, :api_server_url, :verify_url, :proxy,
+      :handle_timeouts_gracefully, :hostname
 
     def initialize #:nodoc:
       @skip_verify_env            = %w[test cucumber]
@@ -36,6 +37,9 @@ module Recaptcha
 
       @secret_key           = ENV['RECAPTCHA_SECRET_KEY']
       @site_key             = ENV['RECAPTCHA_SITE_KEY']
+
+      @api_server_url       = ENV['RECAPTCHA_API_SERVER_URL']
+      @verify_url           = ENV['RECAPTCHA_VERIFY_URL']
     end
 
     def secret_key!
@@ -47,11 +51,11 @@ module Recaptcha
     end
 
     def api_server_url
-      CONFIG.fetch('server_url')
+      @api_server_url || CONFIG.fetch('server_url')
     end
 
     def verify_url
-      CONFIG.fetch('verify_url')
+      @verify_url || CONFIG.fetch('verify_url')
     end
   end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,9 +1,34 @@
 require_relative 'helper'
+require 'pry-byebug'
 
 describe Recaptcha::Configuration do
   describe "#api_server_url" do
     it "serves the default" do
       Recaptcha.configuration.api_server_url.must_equal "https://www.google.com/recaptcha/api.js"
+    end
+
+    describe "when api_server_url is overwritten" do
+      it "serves the overwritten url" do
+        proxied_api_server_url = 'https://127.0.0.1:8080/recaptcha/api.js'
+        Recaptcha.with_configuration(api_server_url: proxied_api_server_url) do
+          Recaptcha.configuration.api_server_url.must_equal proxied_api_server_url
+        end
+      end
+    end
+  end
+
+  describe "#verify_url" do
+    it "serves the default" do
+      Recaptcha.configuration.verify_url.must_equal "https://www.google.com/recaptcha/api/siteverify"
+    end
+
+    describe "when api_server_url is overwritten" do
+      it "serves the overwritten url" do
+        proxied_verify_url = 'https://127.0.0.1:8080/recaptcha/api/siteverify'
+        Recaptcha.with_configuration(verify_url: proxied_verify_url) do
+          Recaptcha.configuration.verify_url.must_equal proxied_verify_url
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This is so that the URL can be set to some proxies instead of the
hardcoded Google links.
This commit is inspired by https://github.com/ambethia/recaptcha/issues/214\#issuecomment-285257412