### PR TITLE
correctly generate data-expired-callback attribute name

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -70,7 +70,7 @@ module Recaptcha
       # Pull out reCaptcha specific data attributes.
       [:badge, :theme, :type, :callback, :expired_callback, :size].each do |data_attribute|
         if value = options.delete(data_attribute)
-          attributes["data-#{data_attribute}"] = value
+          attributes["data-#{data_attribute.to_s.tr('_', '-')}"] = value
         end
       end
 


### PR DESCRIPTION
Specifying the `:expired_callback` attribute to `recaptcha_tags` incorrectly generates `data-expired_callback` name instead of `data-expired-callback`.