### PR TITLE
Update README.md to have alternative config use correct names?

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ Recaptcha.configuration.skip_verify_env.delete("test")
 ```Ruby
 # config/initializers/recaptcha.rb
 Recaptcha.configure do |config|
-  config.site_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
-  config.secret_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+  config.public_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
+  config.private_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
   # Uncomment the following line if you are using a proxy server:
   # config.proxy = 'http://myproxy.com.au:8080'
 end


### PR DESCRIPTION
I was just following the instructions and got this error:

```
config/initializers/recaptcha.rb:2:in `block in <top (required)>': undefined method `site_key=' for #<Recaptcha::Configuration:0x007f9606ad9a78> (NoMethodError)
Did you mean?  private_key=
```
Seems like the config names have changed - I've updated them to ones that work in this PR
