### PR TITLE
Add default callback for invisible recaptcha #220

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,25 @@ Some of the options available:
 
 ## invisible_recaptcha_tags
 
-[Invisible reCAPTCHA](https://developers.google.com/recaptcha/docs/invisible) has two differences:
+Make sure to read [Invisible reCAPTCHA](https://developers.google.com/recaptcha/docs/invisible).
 
-1. Needs a callback function, which is called after verification with Google's reCAPTCHA service. This callback function must submit the form.
-2. The `invisible_recaptcha_tags` generates a submit button.
+### With a single form on a page
+
+1. The `invisible_recaptcha_tags` generates a submit button for you.
+
+```Erb
+<%= form_for @foo do |f| %>
+  # ... other tags
+  <%= invisible_recaptcha_tags text: 'Submit form' %>
+<% end %>
+```
+
+Then, add `verify_recaptcha` to your controller as seen [above](#rails-installation).
+
+### With multiple forms on a page
+
+1. You will need a custom callback function, which is called after verification with Google's reCAPTCHA service. This callback function must submit the form. Optionally, `invisible_recaptcha_tags` currently implements a JS function called `invisibleRecaptchaSubmit` that is called when no `callback` is passed. Should you wish to override `invisibleRecaptchaSubmit`, you will need to use `invisible_recaptcha_tags script: false`, see lib/recaptcha/client_helper.rb for details.
+2. The `invisible_recaptcha_tags` generates a submit button for you.
 
 ```Erb
 <%= form_for @foo, html: {id: 'invisible-recaptcha-form'} do |f| %>

--- a/demo/rails/app/views/captcha/index.html.erb
+++ b/demo/rails/app/views/captcha/index.html.erb
@@ -37,13 +37,8 @@
   <% end %>
   <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
 <% elsif params[:invisible] %>
-  <script>
-    var onSubmitCallback = function() {
-      document.getElementById("invisible-recaptcha-form").submit();
-    }
-  </script>
   <%= form_tag "/captchas", id: "invisible-recaptcha-form" do %>
-    <%= invisible_recaptcha_tags callback: 'onSubmitCallback', text: 'Save changes' %>
+    <%= invisible_recaptcha_tags text: 'Save changes' %>
   <% end %>
 <% else %>
   <%= form_tag "/captchas" do %>

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -95,5 +95,15 @@ describe Recaptcha::ClientHelper do
       html.wont_include("<script")
       html.wont_include("data-sitekey=")
     end
+
+    it "renders default callback if no callback is given" do
+      html = invisible_recaptcha_tags
+      html.must_include("var invisibleRecaptchaSubmit")
+    end
+
+    it "doesn't render default callback script if a callback is given" do
+      html = invisible_recaptcha_tags(callback: 'customCallback')
+      html.wont_include("var invisibleRecaptchaSubmit")
+    end
   end
 end


### PR DESCRIPTION
~This is a work in progress commit and looking for some ideas.
It is working towards the first part of #220.~

~This adds a default callback that calls the function
`invisibleRecaptchaSubmit` if no callback was passed to
`invisible_recaptcha_tags`~

~The drawback to this approach is that it won't work if there are
multiple recaptcha forms.~

Add default callback for invisible recaptcha #220
    
This adds a default callback that calls the function
`invisibleRecaptchaSubmit` if no callback was passed to
`invisible_recaptcha_tags`. The function, `invisibleRecaptchaSubmit`,
uses the `closest()` method to find the closest form to the
`.g-recaptcha` element. However, not all browsers support `closest()`,
so in that case, a polyfill of `closest` is executed. The polyfill is
based on MDN's polyfill suggestion which should support IE9+
https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
    
The drawback to this approach is that it won't work if there are
multiple recaptcha forms. If you want to use invisible_recaptcha_tags
with multiple forms, you would still need to use custom callbacks.