### PR TITLE
Skip optional remote ip when posting

### DIFF
--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -63,7 +63,6 @@ module Recaptcha
 
     def recaptcha_verify_via_api_call(request, recaptcha_response, options)
       secret_key = options[:secret_key] || Recaptcha.configuration.secret_key!
-      
 
       verify_hash = {
         "secret"    => secret_key,

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -63,17 +63,22 @@ module Recaptcha
 
     def recaptcha_verify_via_api_call(request, recaptcha_response, options)
       secret_key = options[:secret_key] || Recaptcha.configuration.secret_key!
-      remote_ip = (request.respond_to?(:remote_ip) && request.remote_ip) || (env && env['REMOTE_ADDR'])
+      
 
       verify_hash = {
         "secret"    => secret_key,
-        "remoteip"  => remote_ip.to_s,
         "response"  => recaptcha_response
       }
+
+      verify_hash.merge!( "remoteip"  => remote_ip.to_s ) unless options[:skip_remote_ip]
 
       reply = JSON.parse(Recaptcha.get(verify_hash, options))
       reply['success'].to_s == "true" &&
         recaptcha_hostname_valid?(reply['hostname'], options[:hostname])
+    end
+
+    def remote_ip
+      (request.respond_to?(:remote_ip) && request.remote_ip) || (env && env['REMOTE_ADDR'])
     end
 
     def recaptcha_hostname_valid?(hostname, validation)

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -70,7 +70,7 @@ module Recaptcha
         "response"  => recaptcha_response
       }
 
-      verify_hash.merge!( "remoteip"  => remote_ip.to_s ) unless options[:skip_remote_ip]
+      verify_hash["remoteip"] = remote_ip.to_s  unless options[:skip_remote_ip]
 
       reply = JSON.parse(Recaptcha.get(verify_hash, options))
       reply['success'].to_s == "true" &&

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -70,14 +70,14 @@ module Recaptcha
         "response"  => recaptcha_response
       }
 
-      verify_hash["remoteip"] = remote_ip.to_s  unless options[:skip_remote_ip]
+      verify_hash["remoteip"] = remote_ip(request).to_s  unless options[:skip_remote_ip]
 
       reply = JSON.parse(Recaptcha.get(verify_hash, options))
       reply['success'].to_s == "true" &&
         recaptcha_hostname_valid?(reply['hostname'], options[:hostname])
     end
 
-    def remote_ip
+    def remote_ip(request)
       (request.respond_to?(:remote_ip) && request.remote_ip) || (env && env['REMOTE_ADDR'])
     end
 

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -81,7 +81,7 @@ describe Recaptcha::Verify do
         :get,
         "https://www.google.com/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
       ).to_return(body: '{"success":true}')
-      
+
       assert @controller.verify_recaptcha(skip_remote_ip: true)
       assert_nil @controller.flash[:recaptcha_error]
     end

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -76,8 +76,12 @@ describe Recaptcha::Verify do
 
     it "returns true on success without remote_ip" do
       @controller.flash[:recaptcha_error] = "previous error that should be cleared"
-      expect_http_post_without_ip.to_return(body: '{"success":true}')
-
+      secret_key = Recaptcha.configuration.secret_key
+      stub_request(
+        :get,
+        "https://www.google.com/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
+      ).to_return(body: '{"success":true}')
+      
       assert @controller.verify_recaptcha(skip_remote_ip: true)
       assert_nil @controller.flash[:recaptcha_error]
     end
@@ -253,13 +257,6 @@ describe Recaptcha::Verify do
     stub_request(
       :get,
       "https://www.google.com/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{secret_key}"
-    )
-  end
-
-  def expect_http_post_without_ip(secret_key: Recaptcha.configuration.secret_key)
-    stub_request(
-      :get,
-      "https://www.google.com/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
     )
   end
 end

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -74,6 +74,14 @@ describe Recaptcha::Verify do
       assert_nil @controller.flash[:recaptcha_error]
     end
 
+    it "returns true on success without remote_ip" do
+      @controller.flash[:recaptcha_error] = "previous error that should be cleared"
+      expect_http_post_without_ip.to_return(body: '{"success":true}')
+
+      assert @controller.verify_recaptcha(skip_remote_ip: true)
+      assert_nil @controller.flash[:recaptcha_error]
+    end
+
     it "fails silently when timing out" do
       expect_http_post.to_timeout
       refute @controller.verify_recaptcha
@@ -245,6 +253,13 @@ describe Recaptcha::Verify do
     stub_request(
       :get,
       "https://www.google.com/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{secret_key}"
+    )
+  end
+
+  def expect_http_post_without_ip(secret_key: Recaptcha.configuration.secret_key)
+    stub_request(
+      :get,
+      "https://www.google.com/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
     )
   end
 end


### PR DESCRIPTION
The `remoteip` to verify captcha is optional as per https://developers.google.com/recaptcha/docs/verify. 

Adding an option to skip the remoteip when necessary