### PR TITLE
Update readme to create site key for localhost:3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ which throws an error on failiure.
 
 ## Rails Installation
 
-[obtain a reCAPTCHA API key](https://www.google.com/recaptcha/admin).
+[obtain a reCAPTCHA API key](https://www.google.com/recaptcha/admin). Note: Use localhost or 127.0.0.1 in domain if using localhost:3000.
 
 ```Ruby
 gem "recaptcha", require: "recaptcha/rails"


### PR DESCRIPTION
If user is working on localost:3000 then localhost will work as a valid domain because localhost:3000 as a domain violates the valid scheme
closes https://github.com/ambethia/recaptcha/issues/241