### PR TITLE
Include `data-tabindex` attribute

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -71,7 +71,7 @@ module Recaptcha
         fallback_uri = %(#{script_url.chomp(".js")}/fallback?k=#{site_key})
 
         # Pull out reCaptcha specific data attributes.
-        [:badge, :theme, :type, :callback, :expired_callback, :size].each do |data_attribute|
+        [:badge, :theme, :type, :callback, :expired_callback, :size, :tabindex].each do |data_attribute|
           value = options.delete(data_attribute)
 
           attributes["data-#{data_attribute}"] = value if value

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -91,8 +91,8 @@ describe Recaptcha::ClientHelper do
     end
 
     it "includes the site key in the button attributes" do
-      html = recaptcha_tags(tabindex: 0)
-      html.must_include(" data-tabindex=\"0\"")
+      html = invisible_recaptcha_tags
+      html.must_include(" data-sitekey=\"#{Recaptcha.configuration.site_key}\"")
     end
 
     it "doesn't render script tag when verification is disabled" do

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -36,6 +36,11 @@ describe Recaptcha::ClientHelper do
     html.must_include(" id=\"my_id\"")
   end
 
+  it "includes tabindex attribute" do
+    html = invisible_recaptcha_tags
+    html.must_include(" data-sitekey=\"#{Recaptcha.configuration.site_key}\"")
+  end
+
   it "does not include <script> tag when setting script: false" do
     html = recaptcha_tags(script: false)
     html.wont_include("<script")
@@ -86,8 +91,8 @@ describe Recaptcha::ClientHelper do
     end
 
     it "includes the site key in the button attributes" do
-      html = invisible_recaptcha_tags
-      html.must_include(" data-sitekey=\"#{Recaptcha.configuration.site_key}\"")
+      html = recaptcha_tags(tabindex: 0)
+      html.must_include(" data-tabindex=\"0\"")
     end
 
     it "doesn't render script tag when verification is disabled" do

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -37,8 +37,8 @@ describe Recaptcha::ClientHelper do
   end
 
   it "includes tabindex attribute" do
-    html = invisible_recaptcha_tags
-    html.must_include(" data-sitekey=\"#{Recaptcha.configuration.site_key}\"")
+    html = recaptcha_tags(tabindex: 123)
+    html.must_include(" data-tabindex=\"123\"")
   end
 
   it "does not include <script> tag when setting script: false" do


### PR DESCRIPTION
This PR pulls out the `tabindex` data attribute, as documented here https://developers.google.com/recaptcha/docs/display