### PR TITLE
Ignore site key for skipped environments

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -56,7 +56,6 @@ module Recaptcha
     end
 
     def self.recaptcha_components(options = {})
-      site_key = options.delete(:site_key) || Recaptcha.configuration.site_key!
       html = ""
       attributes = {}
       fallback_uri = ""
@@ -64,6 +63,7 @@ module Recaptcha
       attributes["class"] = "g-recaptcha #{options.delete(:class)}"
 
       unless Recaptcha::Verify.skip?(options[:env])
+        site_key = options.delete(:site_key) || Recaptcha.configuration.site_key!
         hl = options.delete(:hl).to_s
         script_url = Recaptcha.configuration.api_server_url
         script_url += "?hl=#{hl}" unless hl == ""


### PR DESCRIPTION
Currently, a site key is required even for environments where verification is skipped. It is inconvenient to have to define one when it serves no actual purpose.

This PR removes that requirement.