### PR TITLE
added title attribute to iframe for screen readers

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -25,6 +25,7 @@ module Recaptcha
                     src="#{fallback_uri}"
                     frameborder="0" scrolling="no"
                     style="width: 302px; height:422px; border-style: none;">
+                    title="ReCAPTCHA"
                   </iframe>
                 </div>
               </div>


### PR DESCRIPTION
Screen reader testers log an error on the Recaptcha iframe because it doesn't have a title