### PR TITLE
Dasherise the `data-expired-callback` attribute name properly.

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -75,7 +75,7 @@ module Recaptcha
         [:badge, :theme, :type, :callback, :expired_callback, :size, :tabindex].each do |data_attribute|
           value = options.delete(data_attribute)
 
-          attributes["data-#{data_attribute}"] = value if value
+          attributes["data-#{data_attribute.to_s.dasherize}"] = value if value
         end
 
         attributes["data-sitekey"] = site_key

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -75,7 +75,7 @@ module Recaptcha
         [:badge, :theme, :type, :callback, :expired_callback, :size, :tabindex].each do |data_attribute|
           value = options.delete(data_attribute)
 
-          attributes["data-#{data_attribute.to_s.dasherize}"] = value if value
+          attributes["data-#{data_attribute.to_s.tr('_', '-')}"] = value if value
         end
 
         attributes["data-sitekey"] = site_key

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -63,6 +63,11 @@ describe Recaptcha::ClientHelper do
     html.must_include(" data-sitekey=\"#{Recaptcha.configuration.site_key}\"")
   end
 
+  it "dasherizes the expired_callback attribute name" do
+    html = recaptcha_tags(expired_callback: 'my_expired_callback')
+    html.must_include(" data-expired-callback=\"my_expired_callback\"")
+  end
+
   describe "invisible recaptcha" do
     it "uses ssl" do
       invisible_recaptcha_tags.must_include "\"#{Recaptcha.configuration.api_server_url}\""


### PR DESCRIPTION
Calling `recaptcha_tags` (or `invisible_recaptcha_tags`) with the `expired_callback` argument generated a `data-expired_callback` attribute that does not achieve anything. This fixes that behaviour.

Essentially adds tests for #227.