### PR TITLE
Prevent leaking recaptcha client_helper options as HTML attributes

### DIFF
--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -95,6 +95,11 @@ describe Recaptcha::ClientHelper do
       html.must_include(" foo_attr=\"foo_value\"")
     end
 
+    it "renders other attributes when verification is disabled" do
+      html = invisible_recaptcha_tags(env: "test", foo_attr: 'foo_value')
+      html.must_include(" foo_attr=\"foo_value\"")
+    end
+
     it "includes the site key in the button attributes" do
       html = invisible_recaptcha_tags
       html.must_include(" data-sitekey=\"#{Recaptcha.configuration.site_key}\"")
@@ -104,6 +109,13 @@ describe Recaptcha::ClientHelper do
       html = invisible_recaptcha_tags(env: "test")
       html.wont_include("<script")
       html.wont_include("data-sitekey=")
+    end
+
+    it "doesn't include recaptcha attributes when verification is disabled" do
+      html = invisible_recaptcha_tags(env: "test")
+      [:badge, :theme, :callback, :expired_callback, :size, :tabindex].each do |data_attribute|
+        html.wont_include("#{data_attribute}=")
+      end
     end
 
     it "renders default callback if no callback is given" do


### PR DESCRIPTION
Fixes #255 

In addition to the specific issue with `callback` called out in #255, all kinds of ruby options could leak out into the HTML. For example, if the `env: 'test'` option was provided, the HTML would include `env="test"`. This commit ensures that `recaptcha_components` always consumes all its options so they won't leak into the HTML. 

It would likely be better design to pass desired HTML attributes in a separate Hash instead of interleaving them with ruby options, but that is beyond the scope of this commit. 

I sought to keep behavior as similar as possible, specifically: 
* `data-*` recaptcha-related attributes are not emitted in skipped environments (before they were emitted incorrectly, without the `data-` prefix)
* `class="g-recaptcha"` is emitted even in skipped environments