### PR TITLE
Add ability to temporarily disable recaptcha on the fly through an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Otherwise see [Alternative API key setup](#alternative-api-key-setup).
 ```
 export RECAPTCHA_SITE_KEY  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
 export RECAPTCHA_SECRET_KEY = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+export RECAPTCHA_DISABLE = (true|false) # Optional
 ```
 
 Add `recaptcha_tags` to the forms you want to protect.
@@ -163,12 +164,6 @@ By default, reCAPTCHA is skipped in "test" and "cucumber" env. To enable it duri
 Recaptcha.configuration.skip_verify_env.delete("test")
 ```
 
-If you need to skip reCAPTCHA for any reason in another environment you can temporarily disable it by running:
-
-```
-export DISABLE_RECAPTCHA=true
-```
-
 ## Alternative API key setup
 
 ### Recaptcha.configure
@@ -180,6 +175,8 @@ Recaptcha.configure do |config|
   config.secret_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
   # Uncomment the following line if you are using a proxy server:
   # config.proxy = 'http://myproxy.com.au:8080'
+  # Uncomment the following line to disable Recaptcha functionality
+  # config.disable = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ By default, reCAPTCHA is skipped in "test" and "cucumber" env. To enable it duri
 Recaptcha.configuration.skip_verify_env.delete("test")
 ```
 
+If you need to skip reCAPTCHA for any reason in another environment you can temporarily disable it by running:
+
+```
+export DISABLE_RECAPTCHA=true
+```
+
 ## Alternative API key setup
 
 ### Recaptcha.configure

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -56,7 +56,7 @@ module Recaptcha
 
     def self.skip?(env)
       env ||= ENV['RACK_ENV'] || ENV['RAILS_ENV'] || (Rails.env if defined? Rails.env)
-      Recaptcha.configuration.skip_verify_env.include? env
+      Recaptcha.configuration.skip_verify_env.include?(env) || ENV['DISABLE_RECAPTCHA'].eql?('true')
     end
 
     private

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -55,8 +55,8 @@ module Recaptcha
     end
 
     def self.skip?(env)
-      env ||= ENV['RACK_ENV'] || ENV['RAILS_ENV'] || (Rails.env if defined? Rails.env)
-      Recaptcha.configuration.skip_verify_env.include?(env) || ENV['DISABLE_RECAPTCHA'].eql?('true')
+      env ||= Recaptcha.configuration.fetch_env
+      Recaptcha.configuration.skip_verify_env.include?(env)
     end
 
     private

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,6 +1,25 @@
 require_relative 'helper'
 
 describe Recaptcha::Configuration do
+  describe "#disable" do
+    it "it doesn't modify skip_verify_env when false" do
+      before = Recaptcha.configuration.skip_verify_env.dup
+      Recaptcha.with_configuration(disable: false) do
+        Recaptcha.configuration.skip_verify_env.must_equal before
+      end
+    end
+
+    it "it modifies skip_verify_env when true" do
+      ENV['RACK_ENV'] = 'verify'
+      before = Recaptcha.configuration.skip_verify_env.dup
+      Recaptcha.with_configuration(disable: true) do
+        Recaptcha.configuration.skip_verify_env.must_equal (before + ['verify'])
+      end
+      Recaptcha.configuration.skip_verify_env.must_equal before
+      ENV.delete('RACK_ENV')
+    end
+  end
+
   describe "#api_server_url" do
     it "serves the default" do
       Recaptcha.configuration.api_server_url.must_equal "https://www.google.com/recaptcha/api.js"

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -47,6 +47,15 @@ describe Recaptcha::Verify do
       end
     end
 
+    it "returns true when disable is set" do
+      Recaptcha.with_configuration(disable: true) do
+        expect_http_post.to_return(body: %({"foo":"false", "bar":"invalid-site-secret-key"}))
+
+        assert @controller.verify_recaptcha
+        assert_nil @controller.flash[:recaptcha_error]
+      end
+    end
+
     it "returns false when secret key is invalid" do
       expect_http_post.to_return(body: %({"foo":"false", "bar":"invalid-site-secret-key"}))
 


### PR DESCRIPTION
It is very useful to be able to turn off reCaptcha through just setting an environment variable. In my case this is useful for developing on a corporate network where it is not possible to hit reCaptcha servers, while still allowing other developers on different networks to be able to test with reCaptcha test keys.