### PR TITLE
Allow setting nonce attribute for reCAPTCHA API script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Some of the options available:
 | :error      | Override the error code returned from the reCAPTCHA API (default `nil`)|
 | :size       | Specify a size (default `nil`)|
 | :hl         | Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. (See [language codes](https://developers.google.com/recaptcha/docs/language)) |
+| :nonce      | Optional. Sets nonce attribute for script. Can be generated via `SecureRandom.base64(32)`. (default `nil`)|
 | :id         | Specify an html id attribute (default `nil`)|
 | :script     | If you do not need to add a script tag by helper you can set the option to false. It's necessary when you add a script tag manualy (default `true`)|
 

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -68,6 +68,7 @@ module Recaptcha
       class_attribute = options.delete(:class)
       site_key = options.delete(:site_key)
       hl = options.delete(:hl).to_s
+      nonce = options.delete(:nonce)
       skip_script = (options.delete(:script) == false)
       data_attributes = {}
       [:badge, :theme, :type, :callback, :expired_callback, :size, :tabindex].each do |data_attribute|
@@ -79,7 +80,8 @@ module Recaptcha
         site_key ||= Recaptcha.configuration.site_key!
         script_url = Recaptcha.configuration.api_server_url
         script_url += "?hl=#{hl}" unless hl == ""
-        html << %(<script src="#{script_url}" async defer></script>\n) unless skip_script
+        nonce_attr = " nonce='#{nonce}'" if nonce
+        html << %(<script src="#{script_url}" async defer#{nonce_attr}></script>\n) unless skip_script
         fallback_uri = %(#{script_url.chomp(".js")}/fallback?k=#{site_key})
         attributes["data-sitekey"] = site_key
         attributes.merge! data_attributes

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -41,6 +41,11 @@ describe Recaptcha::ClientHelper do
     html.must_include(" data-tabindex=\"123\"")
   end
 
+  it "includes nonce attribute" do
+    html = recaptcha_tags(nonce: 'P9Y0b6dLSkApYRdOULGW57XHcYNJJKeLwxA2az/Ka9s=')
+    html.must_include(" nonce='P9Y0b6dLSkApYRdOULGW57XHcYNJJKeLwxA2az/Ka9s='")
+  end
+
   it "does not include <script> tag when setting script: false" do
     html = recaptcha_tags(script: false)
     html.wont_include("<script")


### PR DESCRIPTION
This PR adds a nonce attribute to script tag, which can be set by passing a `nonce` option.

This is necessary for setting CSP (Content-Security-Policy) header.

See: https://developers.google.com/recaptcha/docs/faq#im-using-content-security-policy-csp-on-my-website-how-can-i-configure-it-to-work-with-recaptcha
