### PR TITLE
Validate model object first, helpful when you use xhr/ajax req

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ And, add `verify_recaptcha` logic to each form action that you've protected.
 ```Ruby
 # app/controllers/users_controller.rb
 @user = User.new(params[:user].permit(:name))
-if verify_recaptcha(model: @user) && @user.save
+if @user.save && verify_recaptcha(model: @user)
   redirect_to @user
 else
   render 'new'


### PR DESCRIPTION
I use xhr request to send and validate data, validate model object first - prevent handling errors when you already validate captcha request but not pass own validation errors