### PR TITLE
Prefer ENV['RAILS_ENV'] over ENV['RACK_ENV'] when determining current environment

### DIFF
--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -57,7 +57,7 @@ module Recaptcha
     end
 
     def self.skip?(env)
-      env ||= ENV['RACK_ENV'] || ENV['RAILS_ENV'] || (Rails.env if defined? Rails.env)
+      env ||= ENV['RAILS_ENV'] || ENV['RACK_ENV'] || (Rails.env if defined? Rails.env)
       Recaptcha.configuration.skip_verify_env.include? env
     end
 


### PR DESCRIPTION
When testing with Capybara it's possible to have the RAILS_ENV environment variable == 'test' and RACK_ENV not set.  In this case Puma (if used as the server) can default RACK_ENV to 'development'.  Since this gem currently prefers RACK_ENV over RAILS_ENV it leads to thinking it is in development mode when it is actually in test mode.  This PR swaps over to preferring RAILS_ENV over RACK_ENV which probably makes sense since when using Rails RAILS_ENV will more accurately reflect the current mode.