### PR TITLE
Leave tabindex attribute alone for invisible_recaptcha_tags

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -49,7 +49,7 @@ module Recaptcha
 
     # Invisible reCAPTCHA implementation
     def invisible_recaptcha_tags(options = {})
-      options = {callback: 'invisibleRecaptchaSubmit'}.merge options
+      options = {callback: 'invisibleRecaptchaSubmit', ui: :button}.merge options
       text = options.delete(:text)
       html, tag_attributes = Recaptcha::ClientHelper.recaptcha_components(options)
       html << recaptcha_default_callback if recaptcha_default_callback_required?(options)
@@ -71,8 +71,12 @@ module Recaptcha
       hl = options.delete(:hl).to_s
       nonce = options.delete(:nonce)
       skip_script = (options.delete(:script) == false)
+      ui = options.delete(:ui)
+
+      data_attribute_keys = [:badge, :theme, :type, :callback, :expired_callback, :error_callback, :size]
+      data_attribute_keys << :tabindex unless ui == :button
       data_attributes = {}
-      [:badge, :theme, :type, :callback, :expired_callback, :error_callback, :size, :tabindex].each do |data_attribute|
+      data_attribute_keys.each do |data_attribute|
         value = options.delete(data_attribute)
         data_attributes["data-#{data_attribute.to_s.tr('_', '-')}"] = value if value
       end

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -36,9 +36,14 @@ describe Recaptcha::ClientHelper do
     html.must_include(" id=\"my_id\"")
   end
 
-  it "includes tabindex attribute" do
+  it "translates tabindex attribute to data- attribute for recaptcha_tags" do
     html = recaptcha_tags(tabindex: 123)
     html.must_include(" data-tabindex=\"123\"")
+  end
+
+  it "leaves tabindex attribute as-is for invisible_recaptcha_tags" do
+    html = invisible_recaptcha_tags(tabindex: 123)
+    html.must_include(" tabindex=\"123\"")
   end
 
   it "includes nonce attribute" do


### PR DESCRIPTION
As `invisible_recaptcha_tags` generates a `<button>`, it should have a normal `tabindex` attribute, rather than a `data-tabindex` attribute to be picked up by the Recaptcha JS.