### PR TITLE
invisible_recaptcha_tags: Add 'input' option to 'ui'

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -58,6 +58,8 @@ module Recaptcha
         html << %(<button type="submit" #{tag_attributes}>#{text}</button>\n)
       when :invisible
         html << %(<div data-size="invisible" #{tag_attributes}></div>\n)
+      when :input
+        html << %(<input type="submit" #{tag_attributes}>#{text}</input>\n)
       else
         raise(RecaptchaError, "ReCAPTCHA ui `#{options[:ui]}` is not valid.")
       end

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -154,6 +154,13 @@ describe Recaptcha::ClientHelper do
       html.wont_include("<button")
     end
 
+    it "renders an input element if UI is input" do
+      html = invisible_recaptcha_tags(ui: :input)
+      html.must_include("<input type=\"submit\"")
+      html.must_include("</input>")
+      html.wont_include("<button")
+    end
+
     it "raises an error on an invalid ui option" do
       assert_raises Recaptcha::RecaptchaError do
         invisible_recaptcha_tags(ui: :foo)


### PR DESCRIPTION
# Background
I have a legacy Rails application that uses `<input type="submit">` as opposed to `<button type="submit">`, so the CSS becomes messed up when using `invisible_recaptcha_tags`.

# Summary
In this PR, I've added a `:input` option to `ui:`, which builds an `input` element rather than a `button`.
