### PR TITLE
Make rubocop work again

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,9 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.3
   Include:
     - 'lib/**/*'
     - 'Rakefile'
     - 'Gemfile'
-    - 'Rakefile'
   Exclude:
     - 'vendor/**/*'
     - 'demo/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   Include:
+    - 'lib/**/*'
     - 'Rakefile'
     - 'Gemfile'
     - 'Rakefile'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     mocha (1.5.0)
       metaclass (~> 0.0.1)
     parallel (1.12.1)
-    parser (2.5.1.0)
+    parser (2.5.1.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     pry (0.11.3)
@@ -46,15 +46,15 @@ GEM
     public_suffix (3.0.2)
     rainbow (3.0.0)
     rake (12.3.1)
-    rubocop (0.57.2)
+    rubocop (0.59.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     safe_yaml (1.0.4)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -81,4 +81,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -67,9 +67,9 @@ module Recaptcha
     end
 
     def self.recaptcha_components(options = {})
-      html = ''.dup
+      html = +''
       attributes = {}
-      fallback_uri = ''.dup
+      fallback_uri = +''
 
       # Since leftover options get passed directly through as tag
       # attributes, we must unconditionally delete all our options

--- a/lib/recaptcha/rails.rb
+++ b/lib/recaptcha/rails.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 # deprecated, but let's not blow everyone up
 require 'recaptcha'


### PR DESCRIPTION
For some reason, Rubocop misconfigured file list with only `Rakefile` & `Gemfile`, so I changed that to fix Rubocop linting and fixed the issues.