### PR TITLE
Add onload and render

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Some of the options available:
 | :error            | Override the error code returned from the reCAPTCHA API (default `nil`)|
 | :size             | Specify a size (default `nil`)|
 | :hl               | Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified. (See [language codes](https://developers.google.com/recaptcha/docs/language)) |
+| :onload           | Optional. The name of your callback function to be executed once all the dependencies have loaded. (See [explicit rendering](https://developers.google.com/recaptcha/docs/display#explicit_render))|
+| :render           | Optional. Whether to render the widget explicitly. Defaults to `onload`, which will render the widget in the first g-recaptcha tag it finds. (See [explicit rendering](https://developers.google.com/recaptcha/docs/display#explicit_render))|
 | :nonce            | Optional. Sets nonce attribute for script. Can be generated via `SecureRandom.base64(32)`. (default `nil`)|
 | :id               | Specify an html id attribute (default `nil`)|
 | :script           | If you do not need to add a script tag by helper you can set the option to false. It's necessary when you add a script tag manualy (default `true`)|

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -95,11 +95,11 @@ module Recaptcha
       unless Recaptcha::Verify.skip?(env)
         site_key ||= Recaptcha.configuration.site_key!
         script_url = Recaptcha.configuration.api_server_url
-        query_params = hash_to_query({
+        query_params = hash_to_query(
           hl: hl,
           onload: onload,
           render: render
-        })
+        )
         script_url += "?#{query_params}" unless query_params.empty?
         nonce_attr = " nonce='#{nonce}'" if nonce
         html << %(<script src="#{script_url}" async defer#{nonce_attr}></script>\n) unless skip_script
@@ -151,11 +151,7 @@ module Recaptcha
     end
 
     private_class_method def self.hash_to_query(hash)
-      hash
-        .delete_if { |_, val| val.nil? || val.empty? }
-        .to_a
-        .map { |pair| pair.join('=') }
-        .join('&')
+      hash.delete_if { |_, val| val.nil? || val.empty? }.to_a.map { |pair| pair.join('=') }.join('&')
     end
   end
 end

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -77,7 +77,9 @@ module Recaptcha
       env = options.delete(:env)
       class_attribute = options.delete(:class)
       site_key = options.delete(:site_key)
-      hl = options.delete(:hl).to_s
+      hl = options.delete(:hl)
+      onload = options.delete(:onload)
+      render = options.delete(:render)
       nonce = options.delete(:nonce)
       skip_script = (options.delete(:script) == false)
       ui = options.delete(:ui)
@@ -93,7 +95,12 @@ module Recaptcha
       unless Recaptcha::Verify.skip?(env)
         site_key ||= Recaptcha.configuration.site_key!
         script_url = Recaptcha.configuration.api_server_url
-        script_url += "?hl=#{hl}" unless hl == ""
+        query_params = hash_to_query({
+          hl: hl,
+          onload: onload,
+          render: render
+        })
+        script_url += "?#{query_params}" unless query_params.empty?
         nonce_attr = " nonce='#{nonce}'" if nonce
         html << %(<script src="#{script_url}" async defer#{nonce_attr}></script>\n) unless skip_script
         fallback_uri = %(#{script_url.chomp(".js")}/fallback?k=#{site_key})
@@ -141,6 +148,14 @@ module Recaptcha
       options[:callback] == 'invisibleRecaptchaSubmit' &&
       !Recaptcha::Verify.skip?(options[:env]) &&
       options[:script] != false
+    end
+
+    private_class_method def self.hash_to_query(hash)
+      hash
+        .delete_if { |_, val| val.nil? || val.empty? }
+        .to_a
+        .map { |pair| pair.join('=') }
+        .join('&')
     end
   end
 end

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -58,14 +58,46 @@ describe Recaptcha::ClientHelper do
 
   it "adds :hl option to the url" do
     html = recaptcha_tags(hl: 'en')
-    html.must_include("?hl=en")
+    html.must_include("hl=en")
 
     html = recaptcha_tags(hl: 'ru')
-    html.wont_include("?hl=en")
-    html.must_include("?hl=ru")
+    html.wont_include("hl=en")
+    html.must_include("hl=ru")
 
     html = recaptcha_tags
-    html.wont_include("?hl=")
+    html.wont_include("hl=")
+  end
+
+  it "adds :onload option to the url" do
+    html = recaptcha_tags(onload: 'foobar')
+    html.must_include("onload=foobar")
+
+    html = recaptcha_tags(onload: 'anotherFoobar')
+    html.wont_include("onload=foobar")
+    html.must_include("onload=anotherFoobar")
+
+    html = recaptcha_tags
+    html.wont_include("onload=")
+  end
+
+  it "adds :render option to the url" do
+    html = recaptcha_tags(render: 'onload')
+    html.must_include("render=onload")
+
+    html = recaptcha_tags(render: 'explicit')
+    html.wont_include("render=onload")
+    html.must_include("render=explicit")
+
+    html = recaptcha_tags
+    html.wont_include("render=")
+  end
+
+  it "adds query params to the url" do
+    html = recaptcha_tags(hl: 'en', onload: 'foobar')
+    html.must_include("?")
+    html.must_include("hl=en")
+    html.must_include("&")
+    html.must_include("onload=foobar")
   end
 
   it "includes the site key in the button attributes" do


### PR DESCRIPTION
This allows you pass the `onload` and `render` options which are useful for explicit rendering. More detail on these options in [the docs](https://developers.google.com/recaptcha/docs/display#explicit_render).