### PR TITLE
ALT: Use "https://recaptcha.net" instead of "https://www.google.com" to grant accessibility for worldwide

### DIFF
--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -13,8 +13,8 @@ end
 
 module Recaptcha
   CONFIG = {
-    'server_url' => 'https://www.google.com/recaptcha/api.js',
-    'verify_url' => 'https://www.google.com/recaptcha/api/siteverify'
+    'server_url' => 'https://recaptcha.net/recaptcha/api.js',
+    'verify_url' => 'https://recaptcha.net/recaptcha/api/siteverify'
   }.freeze
 
   USE_SSL_BY_DEFAULT              = false


### PR DESCRIPTION
Some countries cannot access https://www.google.com, using https://recaptcha.net would be helpful.