### PR TITLE
remove deprecated scrolling attribute for iframe

### DIFF
--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -25,7 +25,7 @@ module Recaptcha
                 <div style="width: 302px; height: 422px; position: absolute;">
                   <iframe
                     src="#{fallback_uri}"
-                    scrolling="no" name="ReCAPTCHA"
+                    name="ReCAPTCHA"
                     style="width: 302px; height: 422px; border-style: none; border: 0;">
                   </iframe>
                 </div>

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -26,7 +26,7 @@ module Recaptcha
                   <iframe
                     src="#{fallback_uri}"
                     name="ReCAPTCHA"
-                    style="width: 302px; height: 422px; border-style: none; border: 0;">
+                    style="width: 302px; height: 422px; border-style: none; border: 0; overflow: hidden;">
                   </iframe>
                 </div>
               </div>


### PR DESCRIPTION
The scrolling attribute on the iframe element is obsolete. Use CSS instead