### PR TITLE
Recaptcha.net for international users

### DIFF
--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -31,8 +31,8 @@ module Recaptcha
   #
   class Configuration
     DEFAULTS = {
-      'server_url' => 'https://www.google.com/recaptcha/api.js',
-      'verify_url' => 'https://www.google.com/recaptcha/api/siteverify'
+      'server_url' => 'https://www.recaptcha.net/recaptcha/api.js',
+      'verify_url' => 'https://www.recaptcha.net/recaptcha/api/siteverify'
     }.freeze
 
     attr_accessor :default_env, :skip_verify_env, :secret_key, :site_key, :proxy, :handle_timeouts_gracefully, :hostname

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -3,7 +3,7 @@ require_relative 'helper'
 describe Recaptcha::Configuration do
   describe "#api_server_url" do
     it "serves the default" do
-      Recaptcha.configuration.api_server_url.must_equal "https://www.google.com/recaptcha/api.js"
+      Recaptcha.configuration.api_server_url.must_equal "https://www.recaptcha.net/recaptcha/api.js"
     end
 
     describe "when api_server_url is overwritten" do
@@ -18,7 +18,7 @@ describe Recaptcha::Configuration do
 
   describe "#verify_url" do
     it "serves the default" do
-      Recaptcha.configuration.verify_url.must_equal "https://www.google.com/recaptcha/api/siteverify"
+      Recaptcha.configuration.verify_url.must_equal "https://www.recaptcha.net/recaptcha/api/siteverify"
     end
 
     describe "when api_server_url is overwritten" do

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -79,7 +79,7 @@ describe 'controller helpers' do
       secret_key = Recaptcha.configuration.secret_key
       stub_request(
         :get,
-        "https://www.google.com/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
+        "https://www.recaptcha.net/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
       ).to_return(body: '{"success":true}')
 
       assert @controller.verify_recaptcha(skip_remote_ip: true)
@@ -340,7 +340,7 @@ describe 'controller helpers' do
   def expect_http_post(secret_key: Recaptcha.configuration.secret_key)
     stub_request(
       :get,
-      "https://www.google.com/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{secret_key}"
+      "https://www.recaptcha.net/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{secret_key}"
     )
   end
 


### PR DESCRIPTION
Apologies for the duplicate PR, I was feeling impatient (See #306). For reference, the google documentation [can be found here](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally):
