### PR TITLE
Look for keys in encrypted credentials and ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note: Enter `localhost` or `127.0.0.1` as the domain if using in development wit
 gem "recaptcha"
 ```
 
-You can keep keys out of the code base with environment variables or with Rails [secrets](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secrets).<br/>
+You can keep keys out of the code base with environment variables, with Rails [secrets](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secrets) or with Rails [encrypted credentials](https://guides.rubyonrails.org/security.html#custom-credentials).<br/>
 
 In development, you can use the [dotenv](https://github.com/bkeepers/dotenv) gem. (Make sure to add it above `gem 'recaptcha'`.)
 
@@ -48,6 +48,13 @@ documentation.
 ```shell
 export RECAPTCHA_SITE_KEY   = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
 export RECAPTCHA_SECRET_KEY = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+```
+
+If you use Rails encrypted credentials, make sure the keys are at the top level of the yml file:
+
+```ruby
+RECAPTCHA_SITE_KEY: 6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy
+RECAPTCHA_SECRET_KEY: 6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx
 ```
 
 Add `recaptcha_tags` to the forms you want to protect:

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -43,8 +43,8 @@ module Recaptcha
       @skip_verify_env = %w[test cucumber]
       @handle_timeouts_gracefully = true
 
-      @secret_key = ENV['RECAPTCHA_SECRET_KEY']
-      @site_key = ENV['RECAPTCHA_SITE_KEY']
+      @secret_key = ENV['RECAPTCHA_SECRET_KEY'] || Rails.application.credentials[:RECAPTCHA_SECRET_KEY]
+      @site_key = ENV['RECAPTCHA_SITE_KEY'] || Rails.application.credentials[:RECAPTCHA_SITE_KEY]
       @verify_url = nil
       @api_server_url = nil
     end


### PR DESCRIPTION
Assign site key and secret with encrypted credentials if no ENV variable is
given. The encrypted secrets values need to be at the top level of the
yml file as noted in the readme.

My understanding is that (encrypted) secrets are [going to be deprecated](https://guides.rubyonrails.org/5_2_release_notes.html#credentials) eventually, but I left the language in now because I didn't know if it's going to happen in Rails 6 or not.