### PR TITLE
Use default if timeout is nil

### DIFF
--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -64,7 +64,7 @@ module Recaptcha
     verify_hash = { 'secret' => secret_key, 'response' => response }
     verify_hash['remoteip'] = options[:remote_ip] if options.key?(:remote_ip)
 
-    reply = api_verification(verify_hash, timeout: options[:timeout])
+    reply = api_verification(verify_hash, options[:timeout])
     reply['success'].to_s == 'true' &&
       hostname_valid?(reply['hostname'], options[:hostname]) &&
       action_valid?(reply['action'], options[:action]) &&
@@ -99,7 +99,8 @@ module Recaptcha
     end
   end
 
-  def self.api_verification(verify_hash, timeout: DEFAULT_TIMEOUT)
+  def self.api_verification(verify_hash, timeout)
+    timeout ||= DEFAULT_TIMEOUT
     http = if configuration.proxy
       proxy_server = URI.parse(configuration.proxy)
       Net::HTTP::Proxy(proxy_server.host, proxy_server.port, proxy_server.user, proxy_server.password)

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -64,7 +64,7 @@ module Recaptcha
     verify_hash = { 'secret' => secret_key, 'response' => response }
     verify_hash['remoteip'] = options[:remote_ip] if options.key?(:remote_ip)
 
-    reply = api_verification(verify_hash, options[:timeout])
+    reply = api_verification(verify_hash, timeout: options[:timeout])
     reply['success'].to_s == 'true' &&
       hostname_valid?(reply['hostname'], options[:hostname]) &&
       action_valid?(reply['action'], options[:action]) &&
@@ -99,7 +99,7 @@ module Recaptcha
     end
   end
 
-  def self.api_verification(verify_hash, timeout)
+  def self.api_verification(verify_hash, timeout: nil)
     timeout ||= DEFAULT_TIMEOUT
     http = if configuration.proxy
       proxy_server = URI.parse(configuration.proxy)


### PR DESCRIPTION
With the current implementation the default timeout is never used because a `timeout` argument is always passed to `api_verification`. This was made obvious today when reCAPTCHA was having issues and we saw network request times as long as 2 minutes.