### PR TITLE
V3 remove obsolete script tag

### DIFF
--- a/lib/recaptcha/helpers.rb
+++ b/lib/recaptcha/helpers.rb
@@ -217,7 +217,6 @@ module Recaptcha
             var element = document.getElementById(id);
             element.value = token;
           }
-        </script>
       HTML
     end
 

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -208,5 +208,10 @@ describe 'View helpers' do
       html = recaptcha_v3 action: :foo
       html.must_include('<input type="hidden" name="g-recaptcha-response[foo]" id="g-recaptcha-response-foo" data-sitekey="0000000000000000000000000000000000000000" class="g-recaptcha g-recaptcha-response "/>')
     end
+
+    it "does not have obsole closing script tag" do
+      html = recaptcha_v3 action: :foo
+      assert html.scan(/script/).length.even?
+    end
   end
 end


### PR DESCRIPTION
For `recaptcha_v3` helper there was extra closing script tag.

```html
<script src="https://www.recaptcha.net/recaptcha/api.js?render=0000000000000000000000000000000000000000"   ></script>
        <script>
          // Define function so that we can call it again later if we need to reset it
          // This executes reCAPTCHA and then calls our callback.
          function executeRecaptchaForFoo() {
            grecaptcha.ready(function() {
              grecaptcha.execute('0000000000000000000000000000000000000000', {action: 'foo'}).then(function(token) {
                //console.log('g-recaptcha-response-foo', token)
                setInputWithRecaptchaResponseTokenForFoo('g-recaptcha-response-foo', token)
              });
            });
          };
          // Invoke immediately
          executeRecaptchaForFoo()

          // Async variant so you can await this function from another async function (no need for
          // an explicit callback function then!)
          // Returns a Promise that resolves with the response token.
          async function executeRecaptchaForFooAsync() {
            return new Promise((resolve, reject) => {
              grecaptcha.ready(async function() {
                resolve(await grecaptcha.execute('0000000000000000000000000000000000000000', {action: 'foo'}))
              });
            })
          };

                    var setInputWithRecaptchaResponseTokenForFoo = function(id, token) {
            var element = document.getElementById(id);
            element.value = token;
          }
        </script>

        </script>  # <===== obsolete script tag
```