### PR TITLE
Move documentation for the Recaptcha initialiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add `recaptcha_tags` to the forms you want to protect:
 <% end %>
 ```
 
-Then, add `verify_recaptcha` logic to each form action that you've protected:
+Next, add `verify_recaptcha` logic to each form action that you've protected:
 
 ```ruby
 # app/controllers/users_controller.rb
@@ -69,6 +69,19 @@ if verify_recaptcha(model: @user) && @user.save
   redirect_to @user
 else
   render 'new'
+end
+```
+
+Then make sure that you write an initializer for this gem with the relevant
+configuration settings:
+
+```ruby
+# config/initializers/recaptcha.rb
+Recaptcha.configuration do |config|
+  config.site_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
+  config.secret_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+  # Uncomment the following line if you are using a proxy server:
+  # config.proxy = 'http://myproxy.com.au:8080'
 end
 ```
 
@@ -463,17 +476,6 @@ Recaptcha.configuration.skip_verify_env.delete("test")
 
 ## Alternative API key setup
 
-### Recaptcha.configure
-
-```ruby
-# config/initializers/recaptcha.rb
-Recaptcha.configure do |config|
-  config.site_key  = '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
-  config.secret_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
-  # Uncomment the following line if you are using a proxy server:
-  # config.proxy = 'http://myproxy.com.au:8080'
-end
-```
 
 ### Recaptcha.with_configuration
 


### PR DESCRIPTION
Hi. Thanks for writing/maintaining this gem as it's very useful. I personally found the README a little bit hard to follow so I hope you don't mind my raising a PR to reorder one of the sections. I think that this should also fix a typo in the docs ("Recaptcha.configure" ought to be "Recaptcha.configur**ation**" if I'm not mistaken).
Do let me know if that's ok or if there's anything that you'd like me to change first.
