### PR TITLE
fix. Not working params name.

### DIFF
--- a/lib/recaptcha/adapters/controller_methods.rb
+++ b/lib/recaptcha/adapters/controller_methods.rb
@@ -75,7 +75,7 @@ module Recaptcha
       # the key.
       # @return [String] A response token if one was passed in the params; otherwise, `''`
       def recaptcha_response_token(action = nil)
-        response_param = params['g-recaptcha-response-data']
+        response_param = params['g-recaptcha-response']
         if response_param&.respond_to?(:to_h) # Includes ActionController::Parameters
           response_param[action].to_s
         else


### PR DESCRIPTION
Yesterday updated parameter 

`params['g-recaptcha-response-data']
`
is not working  in「reCAPTCHA v2」

Real response params name is 'g-recaptcha-response'