### PR TITLE
fix verify_recaptcha for v2

### DIFF
--- a/lib/recaptcha/adapters/controller_methods.rb
+++ b/lib/recaptcha/adapters/controller_methods.rb
@@ -70,12 +70,13 @@ module Recaptcha
         request.respond_to?(:format) && request.format == :html && respond_to?(:flash)
       end
 
-      # Extracts response token from params. params['g-recaptcha-response'] should either be a
-      # string or a hash with the action name(s) as keys. If it is a hash, then `action` is used as
-      # the key.
+      # Extracts response token from params. params['g-recaptcha-response-data'] for recaptcha_v3 or
+      # params['g-recaptcha-response'] for recaptcha_tags and invisible_recaptcha_tags and should
+      # either be a string or a hash with the action name(s) as keys. If it is a hash, then `action`
+      # is used as the key.
       # @return [String] A response token if one was passed in the params; otherwise, `''`
       def recaptcha_response_token(action = nil)
-        response_param = params['g-recaptcha-response-data']
+        response_param = params['g-recaptcha-response-data'] || params['g-recaptcha-response']
         if response_param&.respond_to?(:to_h) # Includes ActionController::Parameters
           response_param[action].to_s
         else


### PR DESCRIPTION
For support v2 and v3 we need to check `g-recaptcha-response-data` and  `g-recaptcha-response` parameters 