### PR TITLE
Expose recaptcha reply (and score) to the controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,22 @@ are passed as a hash under `params['g-recaptcha-response-data']` with the action
 It is recommended to pass `external_script: false` on all but one of the calls to
 `recaptcha` since you only need to include the script tag once for a given `site_key`.
 
+## `recaptcha_reply`
+
+After `verify_recaptcha` has been called, you can call `recaptcha_reply` to get the raw reply from recaptcha. This can allow you to get the exact score returned by recaptcha should you need it.
+
+```ruby
+if verify_recaptcha(action: 'login')
+  redirect_to @user
+else
+  score = recaptcha_reply['score']
+  Rails.logger.warn("User #{@user.id} was denied login because of a recaptcha score of #{score}")
+  render 'new'
+end
+```
+
+`recaptcha_reply` will return `nil` if the the reply was not yet fetched.
+
 ## I18n support
 
 reCAPTCHA supports the I18n gem (it comes with English translations)

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -65,10 +65,16 @@ module Recaptcha
     verify_hash['remoteip'] = options[:remote_ip] if options.key?(:remote_ip)
 
     reply = api_verification(verify_hash, timeout: options[:timeout])
-    reply['success'].to_s == 'true' &&
+    success = reply['success'].to_s == 'true' &&
       hostname_valid?(reply['hostname'], options[:hostname]) &&
       action_valid?(reply['action'], options[:action]) &&
       score_above_threshold?(reply['score'], options[:minimum_score])
+
+    if options[:with_reply] == true
+      return success, reply
+    else
+      return success
+    end
   end
 
   def self.hostname_valid?(hostname, validation)

--- a/lib/recaptcha/adapters/controller_methods.rb
+++ b/lib/recaptcha/adapters/controller_methods.rb
@@ -24,7 +24,9 @@ module Recaptcha
               options = options.merge(remote_ip: remoteip.to_s) if remoteip
             end
 
-            Recaptcha.verify_via_api_call(recaptcha_response, options)
+            success, @_recaptcha_reply =
+              Recaptcha.verify_via_api_call(recaptcha_response, options.merge(with_reply: true))
+            success
           end
 
           if verified
@@ -56,6 +58,10 @@ module Recaptcha
 
       def verify_recaptcha!(options = {})
         verify_recaptcha(options) || raise(VerifyError)
+      end
+
+      def recaptcha_reply
+        @_recaptcha_reply if defined?(@_recaptcha_reply)
       end
 
       def recaptcha_error(model, attribute, message)

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -322,6 +322,27 @@ describe 'controller helpers' do
     end
   end
 
+  describe "#recatcha_reply" do
+    let(:default_response_hash) { {
+      success: true,
+      score: 0.97,
+      action: 'homepage',
+    } }
+
+    before do
+      expect_http_post.to_return(body: success_body)
+    end
+
+    it "is initially nil" do
+      assert_nil @controller.recaptcha_reply
+    end
+
+    it "contains the recaptcha reply once verify_recaptcha has been called" do
+      assert verify_recaptcha()
+      assert_equal default_response_hash.to_json, @controller.recaptcha_reply.to_json
+    end
+  end
+
   private
 
   class TestController
@@ -335,6 +356,7 @@ describe 'controller helpers' do
 
     public :verify_recaptcha
     public :verify_recaptcha!
+    public :recaptcha_reply
   end
 
   def expect_http_post(secret_key: Recaptcha.configuration.secret_key)


### PR DESCRIPTION
As mentioned in #343

It would be very helpful to be able to get the recaptcha v3 score, for logging purposes for example, or to have different responses given the score (more than just a binary yes/no)

This PR is WIP, I just want to validate the implementation, as I'm adding some public methods and tweaking a bit the `verify_via_api_call` by returning a tuple which is a bit weird.

If you are ok with the implem, I will add tests and update the doc.
Otherwise, if you have suggestions I'm all ears

Thanks