### PR TITLE
Allow multiple invisible recaptchas on a single page by setting custom selector

### DIFF
--- a/lib/recaptcha/helpers.rb
+++ b/lib/recaptcha/helpers.rb
@@ -139,7 +139,7 @@ module Recaptcha
       skip_script = (options.delete(:script) == false) || (options.delete(:external_script) == false)
       ui = options.delete(:ui)
 
-      data_attribute_keys = [:badge, :theme, :type, :callback, :expired_callback, :error_callback, :size, :selector]
+      data_attribute_keys = [:badge, :theme, :type, :callback, :expired_callback, :error_callback, :size]
       data_attribute_keys << :tabindex unless ui == :button
       data_attributes = {}
       data_attribute_keys.each do |data_attribute|
@@ -271,8 +271,7 @@ module Recaptcha
     private_class_method def self.default_callback(options = {})
       nonce = options[:nonce]
       nonce_attr = " nonce='#{nonce}'" if nonce
-      selector_tag = options[:selector]
-      selector_attr = options[:selector] ? "[data-selector='#{selector_tag}']" : '.g-recaptcha'
+      selector_attr = options[:id] ? "##{options[:id]}" : ".g-recaptcha"
 
       <<-HTML
         <script#{nonce_attr}>

--- a/lib/recaptcha/helpers.rb
+++ b/lib/recaptcha/helpers.rb
@@ -139,7 +139,7 @@ module Recaptcha
       skip_script = (options.delete(:script) == false) || (options.delete(:external_script) == false)
       ui = options.delete(:ui)
 
-      data_attribute_keys = [:badge, :theme, :type, :callback, :expired_callback, :error_callback, :size]
+      data_attribute_keys = [:badge, :theme, :type, :callback, :expired_callback, :error_callback, :size, :selector]
       data_attribute_keys << :tabindex unless ui == :button
       data_attributes = {}
       data_attribute_keys.each do |data_attribute|
@@ -271,6 +271,8 @@ module Recaptcha
     private_class_method def self.default_callback(options = {})
       nonce = options[:nonce]
       nonce_attr = " nonce='#{nonce}'" if nonce
+      selector_tag = options[:selector]
+      selector_attr = options[:selector] ? "[data-selector='#{selector_tag}']" : '.g-recaptcha'
 
       <<-HTML
         <script#{nonce_attr}>
@@ -283,9 +285,9 @@ module Recaptcha
               return curEle.nodeName === 'FORM' ? curEle : null
             };
 
-            var eles = document.getElementsByClassName('g-recaptcha');
-            if (eles.length > 0) {
-              var form = closestForm(eles[0]);
+            var el = document.querySelector("#{selector_attr}")
+            if (!!el) {
+              var form = closestForm(el);
               if (form) {
                 form.submit();
               }

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -209,6 +209,17 @@ describe 'View helpers' do
       html.wont_include("<button")
     end
 
+    it "includes a custom selector if provided" do
+      html = invisible_recaptcha_tags(selector: 'custom-selector')
+      html.must_include("data-selector=\"custom-selector\"")
+      html.must_include("document.querySelector(\"[data-selector='custom-selector']\")")
+    end
+
+    it "uses default selector if no custom selector has been provided" do
+      html = invisible_recaptcha_tags()
+      html.must_include("document.querySelector(\".g-recaptcha\")")
+    end
+
     it "raises an error on an invalid ui option" do
       assert_raises Recaptcha::RecaptchaError do
         invisible_recaptcha_tags(ui: :foo)

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -210,13 +210,13 @@ describe 'View helpers' do
     end
 
     it "includes a custom selector if provided" do
-      html = invisible_recaptcha_tags(selector: 'custom-selector')
-      html.must_include("data-selector=\"custom-selector\"")
-      html.must_include("document.querySelector(\"[data-selector='custom-selector']\")")
+      html = invisible_recaptcha_tags(id: 'custom-selector')
+      html.must_include("id=\"custom-selector\"")
+      html.must_include("document.querySelector(\"#custom-selector\")")
     end
 
     it "uses default selector if no custom selector has been provided" do
-      html = invisible_recaptcha_tags()
+      html = invisible_recaptcha_tags
       html.must_include("document.querySelector(\".g-recaptcha\")")
     end
 


### PR DESCRIPTION
I ran into an issue where I had two forms with `invisible_recaptcha_tags` on a single page. The main form is a contact-us form, while a second newsletter-subscribe form is always present in the footer.

When submitting either form, it would then always submit the form for the _first_ button (`var form = closestForm(eles[0]);`) it could find.

This PR is an attempt to add functionality for passing an optional `selector` prop which lets you have multiple recaptcha-protected forms on a single page, as long as you uniquely name your selector props.

Curious to what you think of this. I realise it's a bit of an edge-case.