### PR TITLE
URLs and some other fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
     env: TASK=rubocop
   allow_failures:
     - rvm: truffleruby-head
-    
 script: bundle exec rake $TASK
 branches:
   only: master

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ License:   [MIT](http://creativecommons.org/licenses/MIT/)<br/>
 Info:      https://github.com/ambethia/recaptcha<br/>
 Bugs:      https://github.com/ambethia/recaptcha/issues<br/>
 
-This gem provides helper methods for the [reCAPTCHA API](https://www.google.com/recaptcha). In your
+This gem provides helper methods for the [reCAPTCHA API](https://www.google.com/recaptcha/about/). In your
 views you can use the `recaptcha_tags` method to embed the needed javascript, and you can validate
 in your controllers with `verify_recaptcha` or `verify_recaptcha!`, which raises an error on
 failure.

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -35,18 +35,18 @@ module Recaptcha
       'verify_url' => 'https://www.google.com/recaptcha/api/siteverify'
     }.freeze
 
-    attr_accessor :default_env, :skip_verify_env, :secret_key, :site_key, :proxy, :handle_timeouts_gracefully, :hostname
-    attr_writer :api_server_url, :verify_url
+    attr_accessor :default_env, :skip_verify_env, :api_server_url, :verify_url, :secret_key, :site_key,
+                  :proxy, :handle_timeouts_gracefully, :hostname
 
     def initialize #:nodoc:
       @default_env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || (Rails.env if defined? Rails.env)
       @skip_verify_env = %w[test cucumber]
       @handle_timeouts_gracefully = true
 
+      @api_server_url = ENV['RECAPTCHA_SERVER_URL'] || DEFAULTS.fetch('server_url')
+      @verify_url = ENV['RECAPTCHA_VERIFY_URL'] || DEFAULTS.fetch('verify_url')
       @secret_key = ENV['RECAPTCHA_SECRET_KEY']
       @site_key = ENV['RECAPTCHA_SITE_KEY']
-      @verify_url = nil
-      @api_server_url = nil
     end
 
     def secret_key!
@@ -55,14 +55,6 @@ module Recaptcha
 
     def site_key!
       site_key || raise(RecaptchaError, "No site key specified.")
-    end
-
-    def api_server_url
-      @api_server_url || DEFAULTS.fetch('server_url')
-    end
-
-    def verify_url
-      @verify_url || DEFAULTS.fetch('verify_url')
     end
   end
 end

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -31,8 +31,8 @@ module Recaptcha
   #
   class Configuration
     DEFAULTS = {
-      'server_url' => 'https://www.recaptcha.net/recaptcha/api.js',
-      'verify_url' => 'https://www.recaptcha.net/recaptcha/api/siteverify'
+      'server_url' => 'https://www.google.com/recaptcha/api.js',
+      'verify_url' => 'https://www.google.com/recaptcha/api/siteverify'
     }.freeze
 
     attr_accessor :default_env, :skip_verify_env, :secret_key, :site_key, :proxy, :handle_timeouts_gracefully, :hostname

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -3,7 +3,7 @@ require_relative 'helper'
 describe Recaptcha::Configuration do
   describe "#api_server_url" do
     it "serves the default" do
-      Recaptcha.configuration.api_server_url.must_equal "https://www.recaptcha.net/recaptcha/api.js"
+      Recaptcha.configuration.api_server_url.must_equal "https://www.google.com/recaptcha/api.js"
     end
 
     describe "when api_server_url is overwritten" do
@@ -18,7 +18,7 @@ describe Recaptcha::Configuration do
 
   describe "#verify_url" do
     it "serves the default" do
-      Recaptcha.configuration.verify_url.must_equal "https://www.recaptcha.net/recaptcha/api/siteverify"
+      Recaptcha.configuration.verify_url.must_equal "https://www.google.com/recaptcha/api/siteverify"
     end
 
     describe "when api_server_url is overwritten" do

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -79,7 +79,7 @@ describe 'controller helpers' do
       secret_key = Recaptcha.configuration.secret_key
       stub_request(
         :get,
-        "https://www.recaptcha.net/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
+        "https://www.google.com/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
       ).to_return(body: '{"success":true}')
 
       assert @controller.verify_recaptcha(skip_remote_ip: true)
@@ -362,7 +362,7 @@ describe 'controller helpers' do
   def expect_http_post(secret_key: Recaptcha.configuration.secret_key)
     stub_request(
       :get,
-      "https://www.recaptcha.net/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{secret_key}"
+      "https://www.google.com/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{secret_key}"
     )
   end
 


### PR DESCRIPTION
Hi,

I'm using this gem conveniently. Thank you for publishing a nice gem.

When I actually used this gem, I noticed that some URLs were out of date.

- References
    - [reCAPTCHA v3  |  Google Developers](https://developers.google.com/recaptcha/docs/v3)
    - [reCAPTCHA v2  |  Google Developers](https://developers.google.com/recaptcha/docs/display)
    - [Verifying the user's response  |  reCAPTCHA  |  Google Developers](https://developers.google.com/recaptcha/docs/verify)

![2020-11-03 10 58 50](https://user-images.githubusercontent.com/215381/97945561-4352d280-1dcb-11eb-94e6-5f5a738647f3.png)

![2020-11-03 10 59 52](https://user-images.githubusercontent.com/215381/97945567-46e65980-1dcb-11eb-9abc-31ff6cb8008f.png)

I've fixed them and will send a pull request. I thought you might want to use old URLs or different URLs in server_url and verify_url, so I've also modified them to be able to use environment variables. I would appreciate it if you could check it.

I confirmed that the test passed below. (I'm temporarily changing the settings in `.travis.yml` in order to run the tests. That change has not been included in this PR.)

https://www.travis-ci.com/github/dounokouno/recaptcha

Thank you.