### PR TITLE
Grecaptcha not defined patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+## 5.8.1
+* added `window.grecaptcha` check to execute recaptcha ready method only if grecaptcha is present
+
 ## 5.8.0
 * Add support for the enterprise API
 

--- a/lib/recaptcha/helpers.rb
+++ b/lib/recaptcha/helpers.rb
@@ -186,11 +186,13 @@ module Recaptcha
           // Define function so that we can call it again later if we need to reset it
           // This executes reCAPTCHA and then calls our callback.
           function #{recaptcha_v3_execute_function_name(action)}() {
-            #{recaptcha_ready_method_name}(function() {
-              #{recaptcha_execute_method_name}('#{site_key}', {action: '#{action}'}).then(function(token) {
-                #{callback}('#{id}', token)
+            if(window.grecaptcha){
+              #{recaptcha_ready_method_name}(function() {
+                #{recaptcha_execute_method_name}('#{site_key}', {action: '#{action}'}).then(function(token) {
+                  #{callback}('#{id}', token)
+                });
               });
-            });
+            }
           };
           // Invoke immediately
           #{recaptcha_v3_execute_function_name(action)}()
@@ -218,11 +220,13 @@ module Recaptcha
       <<-HTML
         <script#{nonce_attr}>
           function #{recaptcha_v3_execute_function_name(action)}() {
-            #{recaptcha_ready_method_name}(function() {
-              #{recaptcha_execute_method_name}('#{site_key}', {action: '#{action}'}).then(function(token) {
-                #{callback}('#{id}', token)
+            if(window.grecaptcha){
+              #{recaptcha_ready_method_name}(function() {
+                #{recaptcha_execute_method_name}('#{site_key}', {action: '#{action}'}).then(function(token) {
+                  #{callback}('#{id}', token)
+                });
               });
-            });
+            }
           };
           #{recaptcha_v3_define_default_callback(callback) if recaptcha_v3_define_default_callback?(callback, action, options)}
         </script>

--- a/lib/recaptcha/version.rb
+++ b/lib/recaptcha/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Recaptcha
-  VERSION = '5.8.0'
+  VERSION = '5.8.1'
 end


### PR DESCRIPTION
Why and what is being done.
Grecaptcha not defined error was being raised occasionally so, added window.grecaptcha check to execute recaptcha ready method only if grecaptcha is present.
## Pre-Merge Checklist
- [ ] CHANGELOG.md updated with short summary
