### PR TITLE
Handle invalid params in ControllerMethods#recaptcha_response_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Gracefully handle invalid params
 
 ## 5.8.0
 * Add support for the enterprise API

--- a/lib/recaptcha/adapters/controller_methods.rb
+++ b/lib/recaptcha/adapters/controller_methods.rb
@@ -83,10 +83,12 @@ module Recaptcha
       # @return [String] A response token if one was passed in the params; otherwise, `''`
       def recaptcha_response_token(action = nil)
         response_param = params['g-recaptcha-response-data'] || params['g-recaptcha-response']
-        if response_param&.respond_to?(:to_h) # Includes ActionController::Parameters
-          response_param[action].to_s
+        response_param = response_param[action] if action && response_param.respond_to?(:key?)
+
+        if String === response_param
+          response_param
         else
-          response_param.to_s
+          ''
         end
       end
     end

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -335,6 +335,73 @@ describe 'controller helpers' do
     end
   end
 
+  describe "#recaptcha_response_token" do
+    it "returns an empty string when params are empty and no action is provided" do
+      @controller.params = {}
+      assert_equal @controller.recaptcha_response_token, ""
+    end
+
+    it "returns an empty string when g-recaptcha-response-data is invalid and no action is provided" do
+      @controller.params = { "g-recaptcha-response-data" => {} }
+      assert_equal @controller.recaptcha_response_token, ""
+    end
+
+    it "returns an empty string when g-recaptcha-response is invalid and no action is provided" do
+      @controller.params = { "g-recaptcha-response" => {} }
+      assert_equal @controller.recaptcha_response_token, ""
+    end
+
+    it "returns the g-recaptcha-response-data when response is valid and no action is provided" do
+      @controller.params = { "g-recaptcha-response-data" => "recaptcha-response-data" }
+      assert_equal @controller.recaptcha_response_token, "recaptcha-response-data"
+    end
+
+    it "returns the g-recaptcha-response  when response is valid and no action is provided" do
+      @controller.params = { "g-recaptcha-response" => "recaptcha-response" }
+      assert_equal @controller.recaptcha_response_token, "recaptcha-response"
+    end
+
+    it "returns an empty string when params are empty and an action is provided" do
+      @controller.params = {}
+      assert_equal @controller.recaptcha_response_token("test"), ""
+    end
+
+    it "returns an empty string when g-recaptcha-response-data params are invalid and an action is provided" do
+      @controller.params = { "g-recaptcha-response-data" => ["\n"] }
+      assert_equal @controller.recaptcha_response_token("test"), ""
+    end
+
+    it "returns an empty string when g-recaptcha-response-data params are nil and an action is provided" do
+      @controller.params = { "g-recaptcha-response-data" => nil }
+      assert_equal @controller.recaptcha_response_token("test"), ""
+    end
+
+    it "returns an empty string when g-recaptcha-response-data params are empty and an action is provided" do
+      @controller.params = { "g-recaptcha-response-data" => {} }
+      assert_equal @controller.recaptcha_response_token("test"), ""
+    end
+
+    it "returns an empty string when g-recaptcha-response-data params are valid but an invalid action is provided" do
+      @controller.params = { "g-recaptcha-response-data" => { "test2" => "recaptcha-response-data" } }
+      assert_equal @controller.recaptcha_response_token("test"), ""
+    end
+
+    it "returns an empty string when g-recaptcha-response params are valid but an invalid action is provided" do
+      @controller.params = { "g-recaptcha-response" => { "test2" => "recaptcha-response-data" } }
+      assert_equal @controller.recaptcha_response_token("test"), ""
+    end
+
+    it "returns the g-recaptcha-response-data action when params are valid and an action is provided" do
+      @controller.params = { "g-recaptcha-response-data" => { "test" => "recaptcha-response-data" } }
+      assert_equal @controller.recaptcha_response_token("test"), "recaptcha-response-data"
+    end
+
+    it "returns the g-recaptcha-response action when params are valid and an action is provided" do
+      @controller.params = { "g-recaptcha-response" => { "test" => "recaptcha-response" } }
+      assert_equal @controller.recaptcha_response_token("test"), "recaptcha-response"
+    end
+  end
+
   private
 
   class TestController
@@ -349,6 +416,7 @@ describe 'controller helpers' do
     public :verify_recaptcha
     public :verify_recaptcha!
     public :recaptcha_reply
+    public :recaptcha_response_token
   end
 
   def expect_http_post(secret_key: Recaptcha.configuration.secret_key)


### PR DESCRIPTION
Fixes: #387

This gracefully handles a situation in which requests are made without a valid `g-recaptcha-response-data` or `g-recaptcha-response` parameter, usually these requests come from automated scripts or bots, but it is preferable to not raise an exception (`TypeError: no implicit conversion from nil to integer`) in this case.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
