### PR TITLE
Feature: Adds api response logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ pkg
 .ruby-gemset
 .ruby-version
 .bundle
+.byebug_history
 
 .gems
 .rbenv-gemsets

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -176,7 +176,11 @@ module Recaptcha
   end
 
   def self.logger(message)
-    Recaptcha.configuration.logger.info(message) if logger?
+    Recaptcha.configuration.logger.info(tagged_message(message)) if logger?
+  end
+
+  def self.tagged_message(message)
+    message.is_a?(Hash) ? message.merge(Recaptcha.configuration.logger_tags) : message
   end
 
   def self.logger?

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -60,11 +60,15 @@ module Recaptcha
   end
 
   def self.verify_via_api_call(response, options)
-    if Recaptcha.configuration.enterprise
+    verification = if Recaptcha.configuration.enterprise
       verify_via_api_call_enterprise(response, options)
     else
       verify_via_api_call_free(response, options)
     end
+
+    logger(verification.last)
+
+    verification
   end
 
   def self.verify_via_api_call_enterprise(response, options)
@@ -169,5 +173,13 @@ module Recaptcha
     request['Content-Type'] = 'application/json; charset=utf-8'
     request.body = JSON.generate(body)
     JSON.parse(http_instance.request(request).body)
+  end
+
+  def self.logger(message)
+    Recaptcha.configuration.logger.info(message) if logger?
+  end
+
+  def self.logger?
+    Recaptcha.configuration.logger?
   end
 end

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -60,15 +60,11 @@ module Recaptcha
   end
 
   def self.verify_via_api_call(response, options)
-    verification = if Recaptcha.configuration.enterprise
+    if Recaptcha.configuration.enterprise
       verify_via_api_call_enterprise(response, options)
     else
       verify_via_api_call_free(response, options)
     end
-
-    logger(verification.last)
-
-    verification
   end
 
   def self.verify_via_api_call_enterprise(response, options)
@@ -89,6 +85,8 @@ module Recaptcha
       action_valid?(token_properties['action'], options[:action]) &&
       score_above_threshold?(reply['score'], options[:minimum_score])
 
+    logger(reply)
+
     if options[:with_reply] == true
       return success, reply
     else
@@ -106,6 +104,8 @@ module Recaptcha
       hostname_valid?(reply['hostname'], options[:hostname]) &&
       action_valid?(reply['action'], options[:action]) &&
       score_above_threshold?(reply['score'], options[:minimum_score])
+
+    logger(reply)
 
     if options[:with_reply] == true
       return success, reply

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -38,7 +38,7 @@ module Recaptcha
     }.freeze
 
     attr_accessor :default_env, :skip_verify_env, :proxy, :secret_key, :site_key, :handle_timeouts_gracefully, :hostname
-    attr_accessor :enterprise, :enterprise_api_key, :enterprise_project_id
+    attr_accessor :enterprise, :enterprise_api_key, :enterprise_project_id, :logger
     attr_writer :api_server_url, :verify_url
 
     def initialize #:nodoc:
@@ -79,6 +79,10 @@ module Recaptcha
 
     def verify_url
       @verify_url || (enterprise ? DEFAULTS.fetch('enterprise_verify_url') : DEFAULTS.fetch('free_verify_url'))
+    end
+
+    def logger?
+      !logger.nil?
     end
   end
 end

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -34,18 +34,18 @@ module Recaptcha
       'free_server_url' => 'https://www.recaptcha.net/recaptcha/api.js',
       'enterprise_server_url' => 'https://www.recaptcha.net/recaptcha/enterprise.js',
       'free_verify_url' => 'https://www.recaptcha.net/recaptcha/api/siteverify',
-      'enterprise_verify_url' => 'https://recaptchaenterprise.googleapis.com/v1beta1/projects'
+      'enterprise_verify_url' => 'https://recaptchaenterprise.googleapis.com/v1beta1/projects',
+      'logger_tags' => { event: 'recaptcha-response' }
     }.freeze
 
     attr_accessor :default_env, :skip_verify_env, :proxy, :secret_key, :site_key, :handle_timeouts_gracefully, :hostname
     attr_accessor :enterprise, :enterprise_api_key, :enterprise_project_id, :logger
-    attr_writer :api_server_url, :verify_url
+    attr_writer :api_server_url, :verify_url, :logger_tags
 
     def initialize #:nodoc:
       @default_env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || (Rails.env if defined? Rails.env)
       @skip_verify_env = %w[test cucumber]
       @handle_timeouts_gracefully = true
-
       @secret_key = ENV['RECAPTCHA_SECRET_KEY']
       @site_key = ENV['RECAPTCHA_SITE_KEY']
 
@@ -55,10 +55,7 @@ module Recaptcha
 
       @verify_url = nil
       @api_server_url = nil
-    end
-
-    def logger_tags
-      { event: "recaptcha-response" }
+      @logger_tags = nil
     end
 
     def secret_key!
@@ -87,6 +84,10 @@ module Recaptcha
 
     def logger?
       !logger.nil?
+    end
+
+    def logger_tags
+      @logger_tags || DEFAULTS.fetch('logger_tags')
     end
   end
 end

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -57,6 +57,10 @@ module Recaptcha
       @api_server_url = nil
     end
 
+    def logger_tags
+      { event: "recaptcha-response" }
+    end
+
     def secret_key!
       secret_key || raise(RecaptchaError, "No secret key specified.")
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -16,6 +16,10 @@ describe Recaptcha::Configuration do
       end
     end
 
+    it "has logger tags" do
+      Recaptcha.configuration.logger_tags.must_equal(event: "recaptcha-response")
+    end
+
     it "has a logger" do
       Recaptcha.with_configuration(logger: @logger) do
         Recaptcha.configuration.logger?.must_equal true

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,6 +1,32 @@
 require_relative 'helper'
 
 describe Recaptcha::Configuration do
+  describe "#logger" do
+    before do
+      @logger = mock('STDOUT')
+    end
+
+    it "is nil" do
+      assert_nil Recaptcha.configuration.logger
+    end
+
+    it "is a Logger class" do
+      Recaptcha.with_configuration(logger: @logger) do
+        Recaptcha.configuration.logger.must_equal @logger
+      end
+    end
+
+    it "has a logger" do
+      Recaptcha.with_configuration(logger: @logger) do
+        Recaptcha.configuration.logger?.must_equal true
+      end
+    end
+
+    it "does not have a logger" do
+      Recaptcha.configuration.logger?.must_equal false
+    end
+  end
+
   describe "#api_server_url" do
     it "serves the default (free API)" do
       Recaptcha.configuration.api_server_url.must_equal "https://www.recaptcha.net/recaptcha/api.js"

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -16,10 +16,6 @@ describe Recaptcha::Configuration do
       end
     end
 
-    it "has logger tags" do
-      Recaptcha.configuration.logger_tags.must_equal(event: "recaptcha-response")
-    end
-
     it "has a logger" do
       Recaptcha.with_configuration(logger: @logger) do
         Recaptcha.configuration.logger?.must_equal true
@@ -28,6 +24,22 @@ describe Recaptcha::Configuration do
 
     it "does not have a logger" do
       Recaptcha.configuration.logger?.must_equal false
+    end
+  end
+
+  describe "#logger_tags" do
+    it "has default logger tags" do
+      Recaptcha.configuration.logger_tags.must_equal(event: "recaptcha-response")
+    end
+
+    it "has overwritten logger tags" do
+      tags = { foo: 'bar' }
+      Recaptcha.configuration.logger_tags = tags
+      begin
+        Recaptcha.configuration.logger_tags.must_equal tags
+      ensure
+        Recaptcha.configuration.logger_tags = nil
+      end
     end
   end
 

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -13,7 +13,7 @@ describe 'controller helpers' do
 
       Recaptcha.with_configuration(logger: @logger) do
         expect_http_post.to_return(body: '{"success":true}')
-        @logger.expects(:info).with("success" => true)
+        @logger.expects(:info).with("success" => true, :event => "recaptcha-response")
         @controller.verify_recaptcha
       end
     end

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -7,6 +7,18 @@ describe 'controller helpers' do
     @controller.params = {:recaptcha_response_field => "response", 'g-recaptcha-response-data' => 'string'}
   end
 
+  describe "logger" do
+    it "logs the response" do
+      @logger = mock('STDOUT')
+
+      Recaptcha.with_configuration(logger: @logger) do
+        expect_http_post.to_return(body: '{"success":true}')
+        @logger.expects(:info).with("success" => true)
+        @controller.verify_recaptcha
+      end
+    end
+  end
+
   describe "#verify_recaptcha!" do
     it "raises when it fails" do
       @controller.expects(:verify_recaptcha).returns(false)


### PR DESCRIPTION
This adds a logger configuration option. This is helpful for debugging mysterious failures.

It requires the logger respond to :info.

```
    Recaptcha.configure do |config|
      config.site_key              = '0000000000000000000000000000000000000000'
      config.secret_key            = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
      config.enterprise_api_key    = 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ'
      config.logger = Logger.new(STDOUT) # or Rails.logger
    end
```


## Pre-Merge Checklist
sorry, I haven't written this... should I put it in "next"?
- [ ] CHANGELOG.md updated with short summary
