### PR TITLE
Configure response limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 * Gracefully handle invalid params
+* allow configuring response limit
 
 ## 5.8.0
 * Add support for the enterprise API

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -14,7 +14,6 @@ end
 
 module Recaptcha
   DEFAULT_TIMEOUT = 3
-  RESPONSE_LIMIT = 4000
 
   class RecaptchaError < StandardError
   end
@@ -56,7 +55,7 @@ module Recaptcha
   end
 
   def self.invalid_response?(resp)
-    resp.empty? || resp.length > RESPONSE_LIMIT
+    resp.empty? || resp.length > configuration.response_limit
   end
 
   def self.verify_via_api_call(response, options)

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -38,7 +38,7 @@ module Recaptcha
     }.freeze
 
     attr_accessor :default_env, :skip_verify_env, :proxy, :secret_key, :site_key, :handle_timeouts_gracefully, :hostname
-    attr_accessor :enterprise, :enterprise_api_key, :enterprise_project_id
+    attr_accessor :enterprise, :enterprise_api_key, :enterprise_project_id, :response_limit
     attr_writer :api_server_url, :verify_url
 
     def initialize #:nodoc:
@@ -55,6 +55,8 @@ module Recaptcha
 
       @verify_url = nil
       @api_server_url = nil
+
+      @response_limit = 4000
     end
 
     def secret_key!


### PR DESCRIPTION
Introduce a configurable response limit for the response.
PR #309 introduced a pre-check for captcha response. A limit of 4000 bytes works good for reCapctha but API-compatible hCaptcha produces much larger responses. This PR allows to set a custom limit and therefore use hHaptcha.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
