### PR TITLE
Add new Rubies to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ jobs:
     name: Test ruby version matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.7', 'truffleruby-head']
+        ruby-version: ['2.7', '3.0', '3.1', 'head', 'truffleruby-head']
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Why and what is being done.

I want to ensure this gem works on new Rubies (e.g. 3.0).

~~This change also includes:~~
- ~~removing `Gemfile.lock` for a more flexible dependency installation~~
- ~~renaming the old RuboCop cop names~~

My fork is working: https://github.com/ybiquitous/recaptcha/pull/1

## Pre-Merge Checklist
- [ ] CHANGELOG.md updated with short summary
