### PR TITLE
Add maixmum score for use with hCaptcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,16 @@ Recaptcha.configure do |config|
 end
 ```
 
+hCaptcha uses a scoring system (higher number more likely to be a bot) which is inverse of the reCaptcha scoring system (lower number more likely to be a bot). As such, a `maximum_score` attribute is provided for use with hCaptcha.
+
+```ruby
+result = verify_recaptcha(maximum_score: 0.7)
+```
+
+| Option           | Description |
+|------------------|-------------|
+| `:maximum_score` | Provide a threshold to meet or fall below. Threshold should be a float between 0 and 1 which will be tested as `score <= maximum_score`. (Default: `nil`) |
+
 ## Misc
  - Check out the [wiki](https://github.com/ambethia/recaptcha/wiki) and leave whatever you found valuable there.
  - [Add multiple widgets to the same page](https://github.com/ambethia/recaptcha/wiki/Add-multiple-widgets-to-the-same-page)

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -82,7 +82,8 @@ module Recaptcha
       token_properties['valid'].to_s == 'true' &&
       hostname_valid?(token_properties['hostname'], options[:hostname]) &&
       action_valid?(token_properties['action'], options[:action]) &&
-      score_above_threshold?(reply['score'], options[:minimum_score])
+      score_above_threshold?(reply['score'], options[:minimum_score]) &&
+      score_below_threshold?(reply['score'], options[:maximum_score])
 
     if options[:with_reply] == true
       [success, reply]
@@ -100,7 +101,8 @@ module Recaptcha
     success = reply['success'].to_s == 'true' &&
       hostname_valid?(reply['hostname'], options[:hostname]) &&
       action_valid?(reply['action'], options[:action]) &&
-      score_above_threshold?(reply['score'], options[:minimum_score])
+      score_above_threshold?(reply['score'], options[:minimum_score]) &&
+      score_below_threshold?(reply['score'], options[:maximum_score])
 
     if options[:with_reply] == true
       [success, reply]
@@ -126,7 +128,7 @@ module Recaptcha
     end
   end
 
-  # Returns true iff score is greater or equal to (>=) minimum_score, or if no minimum_score was specified
+  # Returns true if score is greater or equal to (>=) minimum_score, or if no minimum_score was specified
   def self.score_above_threshold?(score, minimum_score)
     return true if minimum_score.nil?
     return false if score.nil?
@@ -134,6 +136,17 @@ module Recaptcha
     case minimum_score
     when nil, FalseClass then true
     else score >= minimum_score
+    end
+  end
+
+  # Returns true if score is lesser or equal to (<=) maximum_score, or if no maximum_score was specified
+  def self.score_below_threshold?(score, maximum_score)
+    return true if maximum_score.nil?
+    return false if score.nil?
+
+    case maximum_score
+    when nil, FalseClass then true
+    else score <= maximum_score
     end
   end
 

--- a/test/verify_enterprise_test.rb
+++ b/test/verify_enterprise_test.rb
@@ -327,6 +327,52 @@ describe 'controller helpers (enterprise)' do
         assert_nil @controller.flash[:recaptcha_error]
       end
     end
+
+    describe 'score_below_threshold?' do
+      let(:default_response_hash) {
+        {
+          tokenProperties: {
+            valid: true,
+            action: 'homepage'
+          }
+        }
+      }
+
+      it "fails when score is above maximum_score" do
+        expect_http_post.to_return(body: success_body(score: 0.8))
+
+        refute verify_recaptcha(maximum_score: 0.7)
+        assert_flash_error
+      end
+
+      it "fails when response doesn't include a score" do
+        expect_http_post.to_return(body: success_body)
+
+        refute verify_recaptcha(maximum_score: 0.7)
+        assert_flash_error
+      end
+
+      it "passes with score exactly at maximum_score" do
+        expect_http_post.to_return(body: success_body(score: 0.7))
+
+        assert verify_recaptcha(maximum_score: 0.7)
+        assert_nil @controller.flash[:recaptcha_error]
+      end
+
+      it "passes when maximum_score not specified or nil" do
+        expect_http_post.to_return(body: success_body(score: 0.7))
+
+        assert verify_recaptcha()
+        assert_nil @controller.flash[:recaptcha_error]
+      end
+
+      it "passes with false" do
+        expect_http_post.to_return(body: success_body(score: 0.7))
+
+        assert verify_recaptcha(maximum_score: false)
+        assert_nil @controller.flash[:recaptcha_error]
+      end
+    end
   end
 
   describe "#recatcha_reply" do

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -312,6 +312,43 @@ describe 'controller helpers' do
         assert_nil @controller.flash[:recaptcha_error]
       end
     end
+
+    describe 'score_below_threshold?' do
+      let(:default_response_hash) { {
+        success: true,
+        action: 'homepage',
+      } }
+
+      before do
+        expect_http_post.to_return(body: success_body(score: 0.8))
+      end
+
+      it "fails when score is above maximum_score" do
+        refute verify_recaptcha(maximum_score: 0.7)
+        assert_flash_error
+      end
+
+      it "fails when response doesn't include a score" do
+        expect_http_post.to_return(body: success_body())
+        refute verify_recaptcha(maximum_score: 0.8)
+        assert_flash_error
+      end
+
+      it "passes with score exactly at maximum_score" do
+        assert verify_recaptcha(maximum_score: 0.8)
+        assert_nil @controller.flash[:recaptcha_error]
+      end
+
+      it "passes when maximum_score not specified or nil" do
+        assert verify_recaptcha()
+        assert_nil @controller.flash[:recaptcha_error]
+      end
+
+      it "passes with false" do
+        assert verify_recaptcha(maximum_score: false)
+        assert_nil @controller.flash[:recaptcha_error]
+      end
+    end
   end
 
   describe "#recatcha_reply" do


### PR DESCRIPTION
This gem can be used with hCaptcha, but hCaptcha scores are inverse to reCaptcha scores.
hCaptchascores: 0.0 (no risk) to 1.0 (high risk)
reCaptcha scores scores: 0.0 (high risk) to 1.0 (no risk)

This change is meant to add a `maximum_score` attribute that can be called with `verify_recaptcha`.
It works just like `minimum_score`, but allows for the same idea to work when using hCaptcha.

## Pre-Merge Checklist
- [ ] CHANGELOG.md updated with short summary
