### PR TITLE
Fix enterprise_verify_url

### DIFF
--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -34,7 +34,7 @@ module Recaptcha
       'free_server_url' => 'https://www.recaptcha.net/recaptcha/api.js',
       'enterprise_server_url' => 'https://www.recaptcha.net/recaptcha/enterprise.js',
       'free_verify_url' => 'https://www.recaptcha.net/recaptcha/api/siteverify',
-      'enterprise_verify_url' => 'https://recaptchaenterprise.googleapis.com/v1beta1/projects'
+      'enterprise_verify_url' => 'https://recaptchaenterprise.googleapis.com/v1/projects'
     }.freeze
 
     attr_accessor :default_env, :skip_verify_env, :proxy, :secret_key, :site_key, :handle_timeouts_gracefully,

--- a/test/verify_enterprise_test.rb
+++ b/test/verify_enterprise_test.rb
@@ -422,7 +422,7 @@ describe 'controller helpers (enterprise)' do
   )
     stub_request(
       :post,
-      "https://recaptchaenterprise.googleapis.com/v1beta1/projects/#{enterprise_project_id}/assessments?key=#{enterprise_api_key}"
+      "https://recaptchaenterprise.googleapis.com/v1/projects/#{enterprise_project_id}/assessments?key=#{enterprise_api_key}"
     )
   end
 


### PR DESCRIPTION
`enterprise_verify_url` were out of date.
So I updated enterprise_verify_url version from v1beta1 to v1.

- References
  - [reCAPTCHA Enterprise API](https://cloud.google.com/recaptcha-enterprise/docs/reference/rest)
  - [v1beta1 Method: projects.assessments.create](https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1beta1/projects.assessments/create)
  - [v1 Method: projects.assessments.create](https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.assessments/create)

![スクリーンショット 2022-08-24 21 11 59](https://user-images.githubusercontent.com/32705001/186415165-18204f1b-f439-4c06-acfa-040837d2874f.png)

## Pre-Merge Checklist
- [ ] CHANGELOG.md updated with short summary
