### PR TITLE
Fix minimum_score for enterprise API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+## 5.12.2
+* Fix minimum score for enterprise
+
 ## 5.12.1
 * Fix Japanese locale
 

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -77,13 +77,14 @@ module Recaptcha
     body['event']['userIpAddress'] = options[:remote_ip] if options.key?(:remote_ip)
 
     reply = api_verification_enterprise(query_params, body, project_id, timeout: options[:timeout])
+    score = reply.dig('riskAnalysis', 'score')
     token_properties = reply['tokenProperties']
     success = !token_properties.nil? &&
       token_properties['valid'].to_s == 'true' &&
       hostname_valid?(token_properties['hostname'], options[:hostname]) &&
       action_valid?(token_properties['action'], options[:action]) &&
-      score_above_threshold?(reply['score'], options[:minimum_score]) &&
-      score_below_threshold?(reply['score'], options[:maximum_score])
+      score_above_threshold?(score, options[:minimum_score]) &&
+      score_below_threshold?(score, options[:maximum_score])
 
     if options[:with_reply] == true
       [success, reply]

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -77,7 +77,7 @@ module Recaptcha
     body['event']['userIpAddress'] = options[:remote_ip] if options.key?(:remote_ip)
 
     reply = api_verification_enterprise(query_params, body, project_id, timeout: options[:timeout])
-    score = reply.dig('riskAnalysis', 'score')
+    score = reply.dig('riskAnalysis', 'score') || reply['score']
     token_properties = reply['tokenProperties']
     success = !token_properties.nil? &&
       token_properties['valid'].to_s == 'true' &&


### PR DESCRIPTION
Setting the minimum_score attribute to anything would cause the v3 check to fail automatically when using reCAPTCHA Enterprise because the score accessor was incorrect and would return nil every time. I simply corrected the accessor for the score attribute coming back from the API and it works again.


## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
