### PR TITLE
Remove enterprise score fallback and modify enterprise tests to v1 assessments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 5.12.3
+* Remove score fallback for enterprise
+* Update enterprise tests to v1 assessment schema
+
 ## 5.12.2
 * Fix minimum score for enterprise
 

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -77,7 +77,7 @@ module Recaptcha
     body['event']['userIpAddress'] = options[:remote_ip] if options.key?(:remote_ip)
 
     reply = api_verification_enterprise(query_params, body, project_id, timeout: options[:timeout])
-    score = reply.dig('riskAnalysis', 'score') || reply['score']
+    score = reply.dig('riskAnalysis', 'score')
     token_properties = reply['tokenProperties']
     success = !token_properties.nil? &&
       token_properties['valid'].to_s == 'true' &&

--- a/test/verify_enterprise_test.rb
+++ b/test/verify_enterprise_test.rb
@@ -265,6 +265,9 @@ describe 'controller helpers (enterprise)' do
           tokenProperties: {
             valid: true,
             action: 'homepage'
+          },
+          riskAnalysis: {
+            reasons: []
           }
         }
       }
@@ -302,6 +305,9 @@ describe 'controller helpers (enterprise)' do
           tokenProperties: {
             valid: true,
             action: 'homepage'
+          },
+          riskAnalysis: {
+            reasons: []
           }
         }
       }
@@ -348,6 +354,9 @@ describe 'controller helpers (enterprise)' do
           tokenProperties: {
             valid: true,
             action: 'homepage'
+          },
+          riskAnalysis: {
+            reasons: []
           }
         }
       }
@@ -396,7 +405,10 @@ describe 'controller helpers (enterprise)' do
           valid: true,
           action: 'homepage'
         },
-        score: 0.97
+        riskAnalysis: {
+          score: 0.97,
+          reasons: []
+        }
       }
     }
 
@@ -429,7 +441,7 @@ describe 'controller helpers (enterprise)' do
   def success_body(action: nil, score: nil)
     result = default_response_hash
     result[:tokenProperties][:action] = action if action
-    result[:score] = score if score
+    result[:riskAnalysis][:score] = score if score
     result.to_json
   end
 


### PR DESCRIPTION
Hey sorry, I decided to go back and check the reCAPTCHA Enterprise API documentation, and it turns out that the old accessor was correct for the v1beta API, but now on the official v1 api it uses the new accessor exclusively:

https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1beta1/projects.assessments
https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.assessments#ClassificationReason

So I updated the enterprise tests and removed the fallback for the old accessor.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
