### PR TITLE
Add option to ignore null elements in recaptcha_v3 view helper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Added option to ignore_no_element.
 
 ## 5.12.3
 * Remove score fallback for enterprise

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ but only accepts the following options:
 | `:inline_script`    | If `true`, adds an inline script tag that calls `grecaptcha.execute` for the given `site_key` and `action` and calls the `callback` with the resulting response token. Pass `false` if you want to handle calling `grecaptcha.execute` yourself. (default: `true`) |
 | `:element`          | The element to render, if any (default: `:input`)<br/>`:input`: Renders a hidden `<input type="hidden">` tag. The value of this will be set to the response token by the default `setInputWithRecaptchaResponseTokenFor{action}` callback.<br/>`false`: Doesn't render any tag. You'll have to add a custom callback that does something with the token. |
 | `:turbolinks`          | If `true`, calls the js function which executes reCAPTCHA after all the dependencies have been loaded. This cannot be used with the js param `:onload`. This makes reCAPTCHAv3 usable with turbolinks. |
+| `:ignore_no_element`  | If `true`, adds null element checker for forms that can be removed from the page by javascript like modals with forms. |
 
 [JavaScript resource (api.js) parameters](https://developers.google.com/recaptcha/docs/invisible#js_param):
 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ but only accepts the following options:
 | `:inline_script`    | If `true`, adds an inline script tag that calls `grecaptcha.execute` for the given `site_key` and `action` and calls the `callback` with the resulting response token. Pass `false` if you want to handle calling `grecaptcha.execute` yourself. (default: `true`) |
 | `:element`          | The element to render, if any (default: `:input`)<br/>`:input`: Renders a hidden `<input type="hidden">` tag. The value of this will be set to the response token by the default `setInputWithRecaptchaResponseTokenFor{action}` callback.<br/>`false`: Doesn't render any tag. You'll have to add a custom callback that does something with the token. |
 | `:turbolinks`          | If `true`, calls the js function which executes reCAPTCHA after all the dependencies have been loaded. This cannot be used with the js param `:onload`. This makes reCAPTCHAv3 usable with turbolinks. |
-| `:ignore_no_element`  | If `true`, adds null element checker for forms that can be removed from the page by javascript like modals with forms. |
+| `:ignore_no_element`  | If `true`, adds null element checker for forms that can be removed from the page by javascript like modals with forms. (default: true) |
 
 [JavaScript resource (api.js) parameters](https://developers.google.com/recaptcha/docs/invisible#js_param):
 

--- a/lib/recaptcha/helpers.rb
+++ b/lib/recaptcha/helpers.rb
@@ -16,7 +16,7 @@ module Recaptcha
       options[:render] = site_key
       options[:script_async] ||= false
       options[:script_defer] ||= false
-      options[:ignore_no_element] ||= false
+      options[:ignore_no_element] = options.key?(:ignore_no_element) ? options[:ignore_no_element] : true 
       element = options.delete(:element)
       element = element == false ? false : :input
       if element == :input

--- a/lib/recaptcha/helpers.rb
+++ b/lib/recaptcha/helpers.rb
@@ -16,7 +16,7 @@ module Recaptcha
       options[:render] = site_key
       options[:script_async] ||= false
       options[:script_defer] ||= false
-      options[:ignore_no_element] = options.key?(:ignore_no_element) ? options[:ignore_no_element] : true 
+      options[:ignore_no_element] = options.key?(:ignore_no_element) ? options[:ignore_no_element] : true
       element = options.delete(:element)
       element = element == false ? false : :input
       if element == :input
@@ -238,23 +238,12 @@ module Recaptcha
     end
 
     private_class_method def self.recaptcha_v3_define_default_callback(callback, options)
-      if options[:ignore_no_element]
-        <<-HTML
-            var #{callback} = function(id, token) {
-              var element = document.getElementById(id);
-              if (element !== null) {
-                element.value = token;
-              }
-            }
-        HTML
-      else
-        <<-HTML
-            var #{callback} = function(id, token) {
-              var element = document.getElementById(id);
-              element.value = token;
-            }
-        HTML
-      end
+      <<-HTML
+        var #{callback} = function(id, token) {
+          var element = document.getElementById(id);
+          #{element_check_condition(options)} element.value = token;
+        }
+      HTML
     end
 
     # Returns true if we should be adding the default callback.
@@ -340,6 +329,10 @@ module Recaptcha
 
     private_class_method def self.hash_to_query(hash)
       hash.delete_if { |_, val| val.nil? || val.empty? }.to_a.map { |pair| pair.join('=') }.join('&')
+    end
+
+    private_class_method def self.element_check_condition(options)
+      options[:ignore_no_element] ? "if (element !== null)" : ""
     end
   end
 end

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -237,5 +237,15 @@ describe 'View helpers' do
       html = recaptcha_v3 action: :foo
       assert html.scan(/script/).length.even?
     end
+
+    it 'outputs element checking for null when ignore_no_element is true' do
+      output = recaptcha_v3(action: 'foo', ignore_no_element: true)
+      assert_includes output, 'if (element !== null)'
+    end
+
+    it 'does not output element checking for null when ignore_no_element is false' do
+      output = recaptcha_v3(action: 'foo', ignore_no_element: false)
+      refute_includes output, 'if (element !== null)'
+    end
   end
 end

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -238,6 +238,11 @@ describe 'View helpers' do
       assert html.scan(/script/).length.even?
     end
 
+    it "outputs element checking when ignore_no_element is not set" do
+      output = recaptcha_v3(action: 'foo')
+      assert_includes output, 'if (element !== null)'
+    end
+
     it 'outputs element checking for null when ignore_no_element is true' do
       output = recaptcha_v3(action: 'foo', ignore_no_element: true)
       assert_includes output, 'if (element !== null)'


### PR DESCRIPTION
This pull request adds an option to the recaptcha_v3 view helper called ignore_no_element. This option is added to avoid a common issue in which the element of the callback function is null after a modal is closed, causing the function to throw an error. This option is not required, and if it is not set, the view helper will continue to work as usual. This pull request was made to resolve the issue requests in the repo recaptcha. 

<img width="525" alt="image" src="https://user-images.githubusercontent.com/2532265/230751764-aed07a5e-05d3-4b48-b2a1-f28df3bf23c5.png">

Fixes #424 

Let me know if there anything else you would like me to add.

- added test cases
- changelog message
- readme documentation
- backwards compatible changes to recaptcha_v3
-  all passing tests

