### PR TITLE
Permit actions as symbol

### DIFF
--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -125,7 +125,7 @@ module Recaptcha
   def self.action_valid?(action, expected_action)
     case expected_action
     when nil, FalseClass then true
-    else action == expected_action
+    else action == expected_action.to_s
     end
   end
 

--- a/test/verify_enterprise_test.rb
+++ b/test/verify_enterprise_test.rb
@@ -288,6 +288,11 @@ describe 'controller helpers (enterprise)' do
         assert_nil @controller.flash[:recaptcha_error]
       end
 
+      it "passes with a symbol that matches" do
+        assert verify_recaptcha(action: :homepage)
+        assert_nil @controller.flash[:recaptcha_error]
+      end
+
       it "passes with nil" do
         assert verify_recaptcha(action: nil)
         assert_nil @controller.flash[:recaptcha_error]


### PR DESCRIPTION
This commit allows the user to pass in the expected action as a symbol.

Previously we would compare the string action with the symbol action and we'd think the action was invalid because `'homepage' != :homepage`.

Thanks! 😄 

## Pre-Merge Checklist
- [ ] CHANGELOG.md updated with short summary

_(I may need some guidance on updating the CHANGELOG—does this require a version change? )_