### PR TITLE
Add 3.2 to the list of Ruby CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', 'head', 'truffleruby-head']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head', 'truffleruby-head']
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Add 3.2 to the list of Ruby CI versions
 
 ## 5.14.0
 * drop json dependency


### PR DESCRIPTION
Add 3.2 to the list of Ruby CI versions

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
