### PR TITLE
Add HTTP POST support with JSON body for server-side verification (`verify_recaptcha`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 * Add 3.2 to the list of Ruby CI versions
+* Add ability to submit verify_recaptcha via POST with JSON Body with `options[:json] = true`
 
 ## 5.14.0
 * drop json dependency

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Some of the options available:
 | `:response`               | Custom response parameter. (default: `params['g-recaptcha-response-data']`)
 | `:hostname`               | Expected hostname or a callable that validates the hostname, see [domain validation](https://developers.google.com/recaptcha/docs/domain_validation) and [hostname](https://developers.google.com/recaptcha/docs/verify#api-response) docs. (default: `nil`, but can be changed by setting `config.hostname`)
 | `:env`                    | Current environment. The request to verify will be skipped if the environment is specified in configuration under `skip_verify_env`
+| `:json`                   | Boolean; defaults to false; if true, will submit the verification request by POST with the request data in JSON
 
 
 ### `invisible_recaptcha_tags`


### PR DESCRIPTION
Certain reCAPTCHA-compatible services require that the server verification be submitted via POST rather than GET.

An example is Cloudflare Turnstile:
https://developers.cloudflare.com/turnstile/migration/migrating-from-recaptcha/#server-side-integration

That documentation calls out the requirement for the verification call be done via POST.

This PR adds the ability to supply options[:json] = true (defaults to false) to submit the data as POST with JSON body.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
