### PR TITLE
Add key setup to v3 example in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Add key setup to v3 example in README
 
 ## 5.16.0
 * Allow usage of `options[:turbo]` as well as `options[:turbolinks]` for `recaptcha_v3`

--- a/README.md
+++ b/README.md
@@ -305,6 +305,14 @@ With v3, you can let all users log in without any intervention at all if their s
 threshold, and only show a v2 checkbox recaptcha challenge (fall back to v2) if it is below the
 threshold:
 
+This example sets v2 keys through environment variables. For more information on how to set up keys, please refer to the [documentation here](#alternative-api-key-setup).
+
+```bash
+# .env
+RECAPTCHA_SITE_KEY=6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy
+RECAPTCHA_SECRET_KEY=6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx
+```
+
 ```erb
   …
   <% if @show_checkbox_recaptcha %>


### PR DESCRIPTION
I found it a bit confusing to understand how the keys worked when initially going through the examples. The v3 keys were set per call, while the v2 keys were set using environment variables.

I've updated the example to indicate where the v2 keys come from.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary