### PR TITLE
Remove unnecessary id on textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 * Add key setup to v3 example in README
+* Remove unnecessary id from textarea - This was unused and may cause accessability concerns if there is more than one recaptcha on the page due to multiple elements with the same id
 
 ## 5.16.0
 * Allow usage of `options[:turbo]` as well as `options[:turbolinks]` for `recaptcha_v3`

--- a/lib/recaptcha/helpers.rb
+++ b/lib/recaptcha/helpers.rb
@@ -74,7 +74,7 @@ module Recaptcha
               <div style="width: 300px; height: 60px; border-style: none;
                 bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px;
                 background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">
-                <textarea id="g-recaptcha-response" name="g-recaptcha-response"
+                <textarea name="g-recaptcha-response"
                   class="g-recaptcha-response"
                   style="width: 250px; height: 40px; border: 1px solid #c1c1c1;
                   margin: 10px 25px; padding: 0px; resize: none;">


### PR DESCRIPTION
Why and what is being done.

This was unused and may cause accessibility concerns if there is more than one recaptcha on the page due to multiple elements with the same id

Fixes #439 

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
