### PR TITLE
Update to the latest version of bundler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 Why and what is being done.
 
 ## Pre-Merge Checklist
-- [ ] CHANGELOG.md updated with short summary
+- [ ] CHANGELOG.md updated with short summary for user facing changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,4 +79,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.5.5


### PR DESCRIPTION

Why and what is being done.
This prevents the deprecation warning:
> Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.


## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
