### PR TITLE
Drop support for ruby 2.7, add 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head', 'truffleruby-head']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head', 'truffleruby-head']
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Include:
     - 'lib/**/*'
     - 'Rakefile'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add key setup to v3 example in README
 * Remove unnecessary id from textarea - This was unused and may cause accessability concerns if there is more than one recaptcha on the page due to multiple elements with the same id
 * Update to latest version of rubocop
+* Drop support for Ruby 2.7; add Ruby 3.3
 
 ## 5.16.0
 * Allow usage of `options[:turbo]` as well as `options[:turbolinks]` for `recaptcha_v3`

--- a/recaptcha.gemspec
+++ b/recaptcha.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/ambethia/recaptcha"
   s.summary     = s.description = "Helpers for the reCAPTCHA API"
   s.license     = "MIT"
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.0.0'
 
   s.files       = `git ls-files lib rails README.md CHANGELOG.md LICENSE`.split("\n")
 


### PR DESCRIPTION
Why and what is being done.
Ruby 2.7 is past EOL, so we're no longer supporting it.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
