### PR TITLE
Add i18n: de, es, it, pt, pt-BR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Remove unnecessary id from textarea - This was unused and may cause accessability concerns if there is more than one recaptcha on the page due to multiple elements with the same id
 * Update to latest version of rubocop
 * Drop support for Ruby 2.7; add Ruby 3.3
+* Add i18n: de, es, it, pt
 
 ## 5.16.0
 * Allow usage of `options[:turbo]` as well as `options[:turbolinks]` for `recaptcha_v3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Remove unnecessary id from textarea - This was unused and may cause accessability concerns if there is more than one recaptcha on the page due to multiple elements with the same id
 * Update to latest version of rubocop
 * Drop support for Ruby 2.7; add Ruby 3.3
-* Add i18n: de, es, it, pt
+* Add i18n: de, es, it, pt, pt-BR
 
 ## 5.16.0
 * Allow usage of `options[:turbo]` as well as `options[:turbolinks]` for `recaptcha_v3`

--- a/rails/locales/de.yml
+++ b/rails/locales/de.yml
@@ -1,0 +1,5 @@
+de:
+  recaptcha:
+    errors:
+      verification_failed: Die reCAPTCHA-Überprüfung ist fehlgeschlagen, bitte versuchen Sie es erneut.
+      recaptcha_unreachable: Oops, wir konnten Ihre reCAPTCHA-Antwort nicht validieren. Bitte versuchen Sie es erneut.

--- a/rails/locales/es.yml
+++ b/rails/locales/es.yml
@@ -1,0 +1,5 @@
+es:
+  recaptcha:
+    errors:
+      verification_failed: La verificación de reCAPTCHA falló, por favor intente de nuevo.
+      recaptcha_unreachable: Ups, no pudimos validar su respuesta de reCAPTCHA. Por favor intente de nuevo.

--- a/rails/locales/it.yml
+++ b/rails/locales/it.yml
@@ -1,0 +1,5 @@
+it:
+  recaptcha:
+    errors:
+      verification_failed: La verifica reCAPTCHA non è riuscita, si prega di riprovare.
+      recaptcha_unreachable: Ops, non siamo riusciti a convalidare la tua risposta reCAPTCHA. Per favore riprova.

--- a/rails/locales/pt-BR.yml
+++ b/rails/locales/pt-BR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  recaptcha:
+    errors:
+      verification_failed: A verificação do reCAPTCHA falhou, por favor, tente novamente.
+      recaptcha_unreachable: Oops, não conseguimos validar sua resposta do reCAPTCHA. Por favor, tente novamente.

--- a/rails/locales/pt.yml
+++ b/rails/locales/pt.yml
@@ -1,0 +1,5 @@
+pt:
+  recaptcha:
+    errors:
+      verification_failed: A verificação do reCAPTCHA falhou, por favor, tente novamente.
+      recaptcha_unreachable: Oops, não conseguimos validar sua resposta do reCAPTCHA. Por favor, tente novamente.


### PR DESCRIPTION
Just adding a few more languages to the i18n support:

- German
- Spanish
- Italian
- Portuguese
- Portuguese (Brazil)

It's handy to have a wide range of languages supported out-of-the-box so users of the gem don't need to add their own translations every time.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary for user facing changes
