### PR TITLE
Remove inline_script attribute from markup

### DIFF
--- a/lib/recaptcha/helpers.rb
+++ b/lib/recaptcha/helpers.rb
@@ -140,6 +140,7 @@ module Recaptcha
       skip_script = (options.delete(:script) == false) || (options.delete(:external_script) == false)
       ui = options.delete(:ui)
       options.delete(:ignore_no_element)
+      options.delete(:inline_script)
 
       data_attribute_keys = [:badge, :theme, :type, :callback, :expired_callback, :error_callback, :size]
       data_attribute_keys << :tabindex unless ui == :button

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -265,5 +265,12 @@ describe 'View helpers' do
       output = recaptcha_v3(action: 'foo', ignore_no_element: false)
       refute_includes output, 'if (element !== null)'
     end
+
+    it 'does not output an inline script attribute' do
+      output = recaptcha_v3(action: 'foo', inline_script: true)
+      refute_includes output, 'inline_script'
+      output = recaptcha_v3(action: 'foo', inline_script: false)
+      refute_includes output, 'inline_script'
+    end
   end
 end


### PR DESCRIPTION
The 'inline_script' option is leaking out as an attribute for the input element. This is getting flagged by some a11y tools. For example, from https://validator.w3.org/nu:

`Error: Attribute inline_script not allowed on element [input](https://html.spec.whatwg.org/multipage/#the-input-element) at this point.`

I don't think it is necessary in the markup, but alternatively we could move it to a data attribute if there's a need I'm not seeing.