### PR TITLE
Add recaptcha_failure_reason for enchanced error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update to latest version of rubocop
 * Drop support for Ruby 2.7; add Ruby 3.3
 * Add i18n: de, es, it, pt, pt-BR
+* Added recaptcha_failure_reason
 
 ## 5.16.0
 * Allow usage of `options[:turbo]` as well as `options[:turbolinks]` for `recaptcha_v3`

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ export RECAPTCHA_ENTERPRISE_API_KEY    = 'AIzvFyE3TU-g4K_Kozr9F1smEzZSGBVOfLKyup
 export RECAPTCHA_ENTERPRISE_PROJECT_ID = 'my-project'
 ```
 
-_note:_ you'll still have to provide `RECAPTCHA_SITE_KEY`, which will hold the value of your enterprise recaptcha key id. You will not need to provide a `RECAPTCHA_SECRET_KEY`, however. 
+_note:_ you'll still have to provide `RECAPTCHA_SITE_KEY`, which will hold the value of your enterprise recaptcha key id. You will not need to provide a `RECAPTCHA_SECRET_KEY`, however.
 
-`RECAPTCHA_ENTERPRISE_API_KEY` is the enterprise key of your Google Cloud Project, which you can generate here: https://console.cloud.google.com/apis/credentials. 
+`RECAPTCHA_ENTERPRISE_API_KEY` is the enterprise key of your Google Cloud Project, which you can generate here: https://console.cloud.google.com/apis/credentials.
 
 Add `recaptcha_tags` to the forms you want to protect:
 
@@ -488,7 +488,7 @@ are passed as a hash under `params['g-recaptcha-response-data']` with the action
 It is recommended to pass `external_script: false` on all but one of the calls to
 `recaptcha` since you only need to include the script tag once for a given `site_key`.
 
-## `recaptcha_reply`
+## `recaptcha_reply` and `recaptcha_failure_reason`
 
 After `verify_recaptcha` has been called, you can call `recaptcha_reply` to get the raw reply from recaptcha. This can allow you to get the exact score returned by recaptcha should you need it.
 
@@ -503,6 +503,8 @@ end
 ```
 
 `recaptcha_reply` will return `nil` if the the reply was not yet fetched.
+
+`recaptcha_failure_reason` will return information if verification failed. E.g. if params was wrong or api resulted some error-codes.
 
 ## I18n support
 


### PR DESCRIPTION
This update introduces the `recaptcha_failure_reason` method to provide developers with detailed information on common verification failures. This enhancement aims to improve debugging and error handling when integrating to applications.

I had annoying moments debugging errors when using the gem. Gem itself worked nicely but the error messages needed some manual work. E.g. when custom javascripts set the request parameter correctly but with wrong name, the gem didn't give any errors it just failed. I wanted to have simpler error messages. This also helps when logging the results as now I have single method to return some information.

**Key Changes:**
- Added `recaptcha_failure_reason` method in `controller_methods.rb` to return detailed failure reasons.
- Updated `verify_recaptcha` method to set `@_recaptcha_failure_reason` with specific error messages based on the verification outcome.
- Modified `verify_recaptcha!` to raise `VerifyError` with an informative error message.
- Updated tests in `test/verify_test.rb` to cover new failure scenarios and ensure `recaptcha_failure_reason` provides accurate information.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary for user facing changes
