### PR TITLE
Minimum length validation for the recaptcha token param

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,8 @@ Recaptcha.configure do |config|
   config.secret_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
   config.verify_url = 'https://hcaptcha.com/siteverify'
   config.api_server_url = 'https://hcaptcha.com/1/api.js'
-  config.response_limit = { max: 100000, min: 100 }
+  config.response_limit = 100000
+  config.response_minimum = 100
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ Recaptcha.configure do |config|
   config.secret_key = '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
   config.verify_url = 'https://hcaptcha.com/siteverify'
   config.api_server_url = 'https://hcaptcha.com/1/api.js'
-  config.response_limit = 100000
+  config.response_limit = { max: 100000, min: 100 }
 end
 ```
 

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -55,7 +55,7 @@ module Recaptcha
   end
 
   def self.invalid_response?(resp)
-    resp.empty? || resp.length > configuration.response_limit
+    resp.empty? || resp.length > configuration.response_limit[:max] || resp.length < configuration.response_limit[:min]
   end
 
   def self.verify_via_api_call(response, options)

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -55,7 +55,7 @@ module Recaptcha
   end
 
   def self.invalid_response?(resp)
-    resp.empty? || resp.length > configuration.response_limit[:max] || resp.length < configuration.response_limit[:min]
+    resp.empty? || resp.length > configuration.response_limit || resp.length < configuration.response_minimum
   end
 
   def self.verify_via_api_call(response, options)

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -56,7 +56,7 @@ module Recaptcha
       @verify_url = nil
       @api_server_url = nil
 
-      @response_limit = 4000
+      @response_limit = { max: 4000, min:100 }
     end
 
     def secret_key!

--- a/lib/recaptcha/configuration.rb
+++ b/lib/recaptcha/configuration.rb
@@ -38,7 +38,7 @@ module Recaptcha
     }.freeze
 
     attr_accessor :default_env, :skip_verify_env, :proxy, :secret_key, :site_key, :handle_timeouts_gracefully,
-                  :hostname, :enterprise, :enterprise_api_key, :enterprise_project_id, :response_limit
+                  :hostname, :enterprise, :enterprise_api_key, :enterprise_project_id, :response_limit, :response_minimum
     attr_writer :api_server_url, :verify_url
 
     def initialize # :nodoc:
@@ -56,7 +56,8 @@ module Recaptcha
       @verify_url = nil
       @api_server_url = nil
 
-      @response_limit = { max: 4000, min:100 }
+      @response_limit = 4000
+      @response_minimum = 100
     end
 
     def secret_key!

--- a/test/verify_enterprise_test.rb
+++ b/test/verify_enterprise_test.rb
@@ -180,10 +180,20 @@ describe 'controller helpers (enterprise)' do
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
-    it "does not verify via http call when response length exceeds G_RESPONSE_LIMIT" do
+    it "does not verify via http call when response length exceeds G_RESPONSE_MAX_LIMIT" do
       # this returns a 400 or 413 instead of a 200 response with error code
       # typical response length is less than 400 characters
       str = "a" * 4001
+      @controller.params = { 'g-recaptcha-response' => "#{str}"}
+      assert_not_requested :get, %r{\.google\.com}
+      assert_equal false, @controller.verify_recaptcha
+      assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
+    end
+
+    it "does not verify via http call when response length exceeds G_RESPONSE_MIN_LIMIT" do
+      # this returns a 400 or 413 instead of a 200 response with error code
+      # typical response length is less than 100 characters
+      str = "a" * 99
       @controller.params = { 'g-recaptcha-response' => "#{str}"}
       assert_not_requested :get, %r{\.google\.com}
       assert_equal false, @controller.verify_recaptcha

--- a/test/verify_enterprise_test.rb
+++ b/test/verify_enterprise_test.rb
@@ -180,7 +180,7 @@ describe 'controller helpers (enterprise)' do
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
-    it "does not verify via http call when response length exceeds G_RESPONSE_MAX_LIMIT" do
+    it "does not verify via http call when response length exceeds limit" do
       # this returns a 400 or 413 instead of a 200 response with error code
       # typical response length is less than 400 characters
       str = "a" * 4001
@@ -190,7 +190,7 @@ describe 'controller helpers (enterprise)' do
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
-    it "does not verify via http call when response length exceeds G_RESPONSE_MIN_LIMIT" do
+    it "does not verify via http call when response length below limit" do
       # this returns a 400 or 413 instead of a 200 response with error code
       # typical response length is less than 100 characters
       str = "a" * 99

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -199,10 +199,20 @@ describe 'controller helpers' do
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
-    it "does not verify via http call when response length exceeds G_RESPONSE_LIMIT" do
+    it "does not verify via http call when response length exceeds G_RESPONSE_MAX_LIMIT" do
       # this returns a 400 or 413 instead of a 200 response with error code
       # typical response length is less than 400 characters
       str = "a" * 4001
+      @controller.params = { 'g-recaptcha-response' => "#{str}"}
+      assert_not_requested :get, %r{\.google\.com}
+      assert_equal false, @controller.verify_recaptcha
+      assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
+    end
+
+    it "does not verify via http call when response length below G_RESPONSE_MIN_LIMIT" do
+      # this returns a 400 or 413 instead of a 200 response with error code
+      # typical response length is less than 100 characters
+      str = "a" * 99
       @controller.params = { 'g-recaptcha-response' => "#{str}"}
       assert_not_requested :get, %r{\.google\.com}
       assert_equal false, @controller.verify_recaptcha

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -199,7 +199,7 @@ describe 'controller helpers' do
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
-    it "does not verify via http call when response length exceeds G_RESPONSE_MAX_LIMIT" do
+    it "does not verify via http call when response length exceeds limit" do
       # this returns a 400 or 413 instead of a 200 response with error code
       # typical response length is less than 400 characters
       str = "a" * 4001
@@ -209,7 +209,7 @@ describe 'controller helpers' do
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
-    it "does not verify via http call when response length below G_RESPONSE_MIN_LIMIT" do
+    it "does not verify via http call when response length below limit" do
       # this returns a 400 or 413 instead of a 200 response with error code
       # typical response length is less than 100 characters
       str = "a" * 99


### PR DESCRIPTION
Add minimum length validation for the recaptcha token param

Reason:
https://github.com/ambethia/recaptcha/issues/461

Spammers can pass random value for the token param (ex: g-recaptcha-response) which can increase the API validation call to recaptcha, consequently incurring more cost.

Most of the Spam attacks we observed attacher sending 1-10 length chars.
It is good to have minimum length 100, validation check to avoid unnecessary API calls to recaptcha.
