### PR TITLE
Add Reply class to handle Recaptcha responses

### DIFF
--- a/lib/recaptcha/reply.rb
+++ b/lib/recaptcha/reply.rb
@@ -1,0 +1,77 @@
+module Recaptcha
+  class Reply
+    attr_reader :raw_reply, :enterprise
+
+    def initialize(raw_reply, enterprise: false)
+      @raw_reply = raw_reply
+      @enterprise = enterprise
+    end
+
+    def [](key)
+      return send(key.to_sym) if respond_to?(key.to_sym)
+
+      raw_reply[key]
+    end
+
+    def token_properties
+      raw_reply['tokenProperties'] if enterprise?
+    end
+
+    def success?
+      success = enterprise? ? token_properties&.dig('valid') : raw_reply['success']
+
+      success.to_s == 'true'
+    end
+
+    def hostname
+      return raw_reply['hostname'] unless enterprise?
+
+      token_properties&.dig('hostname')
+    end
+
+    def action
+      return raw_reply['action'] unless enterprise?
+
+      token_properties&.dig('action')
+    end
+
+    def score
+      return raw_reply['score'] unless enterprise?
+
+      raw_reply.dig('riskAnalysis', 'score')
+    end
+
+    def error_codes
+      return [] if enterprise?
+
+      raw_reply['error-codes'] || []
+    end
+
+    # Returns the challenge timestamp
+    def challenge_ts
+      return raw_reply['challenge_ts'] unless enterprise?
+
+      token_properties&.dig('createTime')
+    end
+
+    def enterprise?
+      @enterprise
+    end
+
+    def free?
+      !enterprise?
+    end
+
+    def to_h
+      raw_reply
+    end
+
+    def to_s
+      raw_reply.to_s
+    end
+
+    def to_json
+      raw_reply.to_json
+    end
+  end
+end


### PR DESCRIPTION
Add `Recaptcha::Reply` class to standardize and simplify response handling for both free and enterprise versions. It also defines the `[]=` method for backward compatibility.