### PR TITLE
add referer header to #api_verification_entreprise

### DIFF
--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -129,6 +129,7 @@ module Recaptcha
     uri = URI.parse("#{configuration.verify_url}/#{project_id}/assessments?#{query}")
     http_instance = http_client_for(uri: uri, timeout: timeout)
     request = Net::HTTP::Post.new(uri.request_uri)
+    request['Referer'] = Rails.application.default_url_options[:host] if defined? Rails.application
     request['Content-Type'] = 'application/json; charset=utf-8'
     request.body = JSON.generate(body)
     JSON.parse(http_instance.request(request).body)


### PR DESCRIPTION
PR to fix #470.

According to #470, when verifying the `reCAPTCHA` token with `verify_recaptcha`, the HTTP request sent to Google's endpoint does not include a **Referer** header. Google rejects the request with a **403 Permission Denied** error because the request lacks the expected referer/origin information.

This PR adds a **Referer** header during `api_verification_enterprise` method with a default value of `Rails.application.default_url_options[:host]`.

Any improvement is welcome ! 

## Pre-Merge Checklist
- [ ] CHANGELOG.md updated with short summary for user facing changes
