### PR TITLE
Allow flash messages when responding to turbo_stream requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Fix flash not being updated when responding to :turbo_stream requests
 
 ## 5.20.0
 * turn recpatch reply into a object with logic

--- a/lib/recaptcha/adapters/controller_methods.rb
+++ b/lib/recaptcha/adapters/controller_methods.rb
@@ -96,7 +96,9 @@ module Recaptcha
       end
 
       def recaptcha_flash_supported?
-        request.respond_to?(:format) && request.format == :html && respond_to?(:flash)
+        request.respond_to?(:format) && respond_to?(:flash) && (
+          request.format == :html || request.format == :turbo_stream
+        )
       end
 
       # Extracts response token from params. params['g-recaptcha-response-data'] for recaptcha_v3 or


### PR DESCRIPTION
Rails form submissions and redirects are processed as TURBO_STREAM format and not HTML, this means that when calling `verify_recaptcha` without passing a model doesn't create a flash message.

## Pre-Merge Checklist
- [&#x2611;] CHANGELOG.md updated with short summary for user facing changes
