### PR TITLE
Fix skip_env? to fall back to Rails.env when default_env is nil

### DIFF
--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -52,7 +52,9 @@ module Recaptcha
   end
 
   def self.skip_env?(env)
-    configuration.skip_verify_env.include?(env || configuration.default_env)
+    resolved = env || configuration.default_env
+    resolved ||= Rails.env.to_s if defined?(Rails.env)
+    configuration.skip_verify_env.include?(resolved)
   end
 
   def self.invalid_response?(resp)

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -521,3 +521,39 @@ describe 'controller helpers' do
     assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
   end
 end
+
+describe "Recaptcha.skip_env?" do
+  # test/helper.rb deletes RAILS_ENV and RACK_ENV, so default_env is nil in this suite.
+  # This mirrors what can happen in multi-threaded servers (e.g. Puma running system tests)
+  # where the Configuration singleton is initialised before the env var is visible,
+  # leaving default_env as nil even though Rails.env correctly returns "test".
+
+  it "returns true when env argument matches skip_verify_env" do
+    assert Recaptcha.skip_env?("test")
+  end
+
+  it "returns false when env argument is not in skip_verify_env" do
+    refute Recaptcha.skip_env?("production")
+  end
+
+  it "returns false when env argument is nil and default_env is nil" do
+    assert_nil Recaptcha.configuration.default_env
+    refute Recaptcha.skip_env?(nil)
+  end
+
+  describe "when Rails.env is available and in skip_verify_env" do
+    before do
+      rails_stub = Module.new { def self.env; "test"; end }
+      Object.const_set(:Rails, rails_stub)
+    end
+
+    after do
+      Object.send(:remove_const, :Rails) if defined?(Rails)
+    end
+
+    it "returns true even when default_env is nil" do
+      assert_nil Recaptcha.configuration.default_env
+      assert Recaptcha.skip_env?(nil)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

In Rails apps using a multi-threaded server (e.g. Puma) for system tests with Capybara, `verify_recaptcha` intermittently skips the `skip_verify_env` bypass and makes real HTTP verification calls to Google's reCAPTCHA API. These calls fail (timeout or invalid token), causing forms to re-render as if reCAPTCHA verification failed — despite the app running in `RAILS_ENV=test`.

**Root cause:** `Recaptcha::Configuration#default_env` is set once at initialization:

```ruby
@default_env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || (Rails.env if defined? Rails.env)
```

When the singleton initializes before `RAILS_ENV` is fully available in a multi-threaded context, `default_env` is `nil`. Then `skip_env?(nil)` evaluates:

```ruby
configuration.skip_verify_env.include?(nil || nil)  # => false
```

...bypassing the test-mode skip entirely, even though `Rails.env` would correctly return `"test"` at call time.

This is also demonstrated by the gem's own test helper, which explicitly deletes `RAILS_ENV` and `RACK_ENV` (`test/helper.rb` lines 2–3), meaning `default_env` is `nil` throughout the test suite.

## Fix

Fall back to `Rails.env` at call time if `default_env` is nil:

```ruby
def self.skip_env?(env)
  resolved = env || configuration.default_env
  resolved ||= Rails.env.to_s if defined?(Rails.env)
  configuration.skip_verify_env.include?(resolved)
end
```

This ensures the skip check always reflects the current Rails environment, even if the configuration was initialized before `RAILS_ENV` was set.

## Tests

Added four tests for `Recaptcha.skip_env?`:
- Returns true for an explicit env matching `skip_verify_env`
- Returns false for an explicit env not in `skip_verify_env`
- Returns false when both `env` argument and `default_env` are nil (existing behavior, correctly documented)
- **Returns true when `default_env` is nil but `Rails.env` is in `skip_verify_env`** (the bug this fixes)

All 160 tests pass. RuboCop reports no offenses.